### PR TITLE
Add FFmpeg frame extraction CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # decoder-poc
+
+This repository contains experimental utilities for video processing. The first
+module provides a command-line interface for extracting frames from a video
+using FFmpeg.
+
+## Frame Extractor
+
+```
+python -m src.frame_extractor --input input.mp4 --output frames --fps 30
+```
+
+The script logs extraction progress and writes frames as JPEG images in the
+specified directory.

--- a/src/frame_extractor.py
+++ b/src/frame_extractor.py
@@ -1,0 +1,113 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CLI script for extracting video frames using FFmpeg.
+
+Example:
+    python -m src.frame_extractor --input example.mp4 --output frames --fps 30
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+from typing import List
+
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+def build_ffmpeg_command(input_video: str, output_dir: str, fps: int) -> List[str]:
+    """Build the FFmpeg command for frame extraction.
+
+    Args:
+        input_video: Path to the input video file.
+        output_dir: Directory where frames will be written.
+        fps: Frames per second to extract.
+
+    Returns:
+        List of command tokens.
+    """
+    output_pattern = os.path.join(output_dir, "frame_%06d.jpg")
+    return [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        input_video,
+        "-vf",
+        f"fps={fps}",
+        output_pattern,
+        "-progress",
+        "-",
+    ]
+
+
+def extract_frames(input_video: str, output_dir: str, fps: int = 30) -> None:
+    """Extract frames from ``input_video`` into ``output_dir`` using FFmpeg.
+
+    Args:
+        input_video: Video file to read.
+        output_dir: Directory to store extracted frames.
+        fps: Frame extraction rate.
+
+    Raises:
+        FileNotFoundError: If ``input_video`` does not exist.
+        RuntimeError: If FFmpeg fails or is not installed.
+    """
+    if not os.path.isfile(input_video):
+        raise FileNotFoundError(f"Input video '{input_video}' not found.")
+
+    os.makedirs(output_dir, exist_ok=True)
+    cmd = build_ffmpeg_command(input_video, output_dir, fps)
+    logger.info("Running: %s", " ".join(cmd))
+
+    try:
+        with subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+        ) as proc:
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                line = line.strip()
+                if line.startswith("frame="):
+                    logger.info(line)
+            proc.wait()
+            if proc.returncode != 0:
+                raise RuntimeError(f"FFmpeg exited with status {proc.returncode}")
+    except FileNotFoundError as exc:
+        raise RuntimeError("FFmpeg not installed or not found in PATH.") from exc
+
+
+def parse_args(argv: List[str]) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="Extract video frames with FFmpeg")
+    parser.add_argument("--input", required=True, help="Input video path")
+    parser.add_argument("--output", required=True, help="Output folder for frames")
+    parser.add_argument(
+        "--fps", type=int, default=30, help="Frames per second to extract"
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: List[str] | None = None) -> None:
+    """Entry point for the CLI."""
+    args = parse_args(argv or sys.argv[1:])
+    extract_frames(args.input, args.output, args.fps)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/test_frame_extractor.py
+++ b/tests/test_frame_extractor.py
@@ -1,0 +1,70 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`src.frame_extractor`."""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+from pathlib import Path
+from typing import List
+from unittest import mock
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+import src.frame_extractor as fe
+
+
+def fake_popen(expected_cmd: List[str]):
+    """Create a fake ``Popen`` callable returning dummy progress."""
+
+    class FakeProc:
+        def __init__(self):
+            self.stdout = io.StringIO("frame=1\nframe=2\n")
+            self.returncode = 0
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            pass
+
+        def wait(self) -> None:
+            return None
+
+    def _popen(cmd, stdout, stderr, text):
+        assert cmd == expected_cmd
+        return FakeProc()
+
+    return _popen
+
+
+def test_build_ffmpeg_command(tmp_path):
+    cmd = fe.build_ffmpeg_command("video.mp4", str(tmp_path), 30)
+    assert cmd[0] == "ffmpeg"
+    assert f"fps=30" in cmd
+    assert str(tmp_path) in cmd[-3]
+
+
+def test_extract_frames_invokes_ffmpeg(tmp_path, monkeypatch):
+    video = tmp_path / "vid.mp4"
+    video.write_text("dummy")
+    outdir = tmp_path / "frames"
+    expected_cmd = fe.build_ffmpeg_command(str(video), str(outdir), 30)
+
+    monkeypatch.setattr(fe.subprocess, "Popen", fake_popen(expected_cmd))
+    fe.extract_frames(str(video), str(outdir), 30)
+
+    assert outdir.exists()


### PR DESCRIPTION
## Summary
- implement `frame_extractor.py` to extract frames with FFmpeg
- add tests with a mock FFmpeg process
- document usage in README
- ignore Python caches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd78e37ec832f9acb31ce3bb19135