### PR TITLE
Add FFmpeg frame extraction CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # decoder-poc
+
+This project contains experimental utilities for video processing. The `frame_extractor` CLI provides a simple way to extract video frames using FFmpeg.
+
+## Frame Extraction CLI
+
+```
+python src/frame_extractor.py -i <video.mp4> -o /path/to/output -f 30
+```
+
+- `-i`, `--input`: Path to input video.
+- `-o`, `--output`: Output directory for JPEG frames.
+- `-f`, `--fps`: Frames per second to extract (default: 30).
+- `-v`, `--verbose`: Increase logging detail.
+
+Example output logs:
+
+```
+2024-01-01 12:00:00 - INFO - Running command: ffmpeg -i input.mp4 -vf fps=30 output/frame_%06d.jpg -loglevel error -progress pipe:1
+2024-01-01 12:00:01 - INFO - frame=1
+...
+2024-01-01 12:00:02 - INFO - progress=end
+```
+
+The script requires FFmpeg to be installed and available on the system path.
+

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,14 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Package for video processing utilities."""
+
+

--- a/src/frame_extractor.py
+++ b/src/frame_extractor.py
@@ -1,0 +1,123 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CLI script for extracting video frames using FFmpeg."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+def extract_frames(input_video: Path, output_dir: Path, fps: int) -> None:
+    """Extract frames from a video using FFmpeg.
+
+    Args:
+        input_video: Path to the video file.
+        output_dir: Directory to store extracted frames.
+        fps: Frames per second for extraction.
+    """
+    if not input_video.exists():
+        raise FileNotFoundError(f"Input video not found: {input_video}")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    cmd = [
+        "ffmpeg",
+        "-i",
+        str(input_video),
+        "-vf",
+        f"fps={fps}",
+        str(output_dir / "frame_%06d.jpg"),
+        "-loglevel",
+        "error",
+        "-progress",
+        "pipe:1",
+    ]
+
+    LOGGER.info("Running command: %s", " ".join(cmd))
+
+    with subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    ) as proc:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            line = line.strip()
+            if line.startswith("frame="):
+                LOGGER.info(line)
+            elif line.startswith("progress=") and line != "progress=continue":
+                LOGGER.info(line)
+
+    if proc.returncode:
+        raise subprocess.CalledProcessError(proc.returncode, cmd)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "-i",
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to the input video file.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        required=True,
+        help="Directory to save extracted frames.",
+    )
+    parser.add_argument(
+        "-f",
+        "--fps",
+        type=int,
+        default=30,
+        help="Frames per second to extract (default: 30).",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """CLI entrypoint."""
+    args = parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+
+    try:
+        extract_frames(args.input, args.output, args.fps)
+    except Exception as exc:  # pragma: no cover - top-level error handling
+        LOGGER.error("Failed to extract frames: %s", exc)
+        raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_frame_extractor.py
+++ b/tests/test_frame_extractor.py
@@ -1,0 +1,55 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for frame_extractor module."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src import frame_extractor
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg not installed")
+def test_extract_frames(tmp_path: Path) -> None:
+    """Ensure frames are extracted from a short generated video."""
+    video = tmp_path / "test.mp4"
+    output_dir = tmp_path / "frames"
+
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=duration=1:size=128x128:rate=30",
+            str(video),
+            "-loglevel",
+            "error",
+        ],
+        check=True,
+    )
+
+    frame_extractor.extract_frames(video, output_dir, fps=10)
+
+    extracted = list(output_dir.glob("*.jpg"))
+    assert extracted, "No frames were extracted"
+


### PR DESCRIPTION
## Summary
- implement `frame_extractor.py` CLI to extract frames using FFmpeg
- document usage in README
- add pytest covering frame extraction
- ignore pycache files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd78e37ec832f9acb31ce3bb19135