### PR TITLE
Add numpy dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
+# Install base Python dependencies including NumPy
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt \
+    && pip3 install --no-cache-dir 'numpy>=1.26'
 
 WORKDIR /app
 COPY . /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ torchvision>=0.17.2
 timm>=0.9.12
 pillow>=10.3.0
 tqdm>=4.66.2
+
+numpy>=1.26


### PR DESCRIPTION
## Summary
- append numpy>=1.26 to requirements
- install numpy in Dockerfile so image rebuilds with new dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d4e9cf40832fa0918d7c9a335790