### PR TITLE
fix: correct Swin2SR model

### DIFF
--- a/src/frame_enhancer.py
+++ b/src/frame_enhancer.py
@@ -60,7 +60,7 @@ def _load_model(device: str):
     import timm
     import torch
 
-    model = timm.create_model("swin2sr-lightweight-x4-128", pretrained=True)
+    model = timm.create_model("swin2sr-lightweight-x4-64", pretrained=True)
 
     model = model.eval().to(device)
     return model

--- a/tests/test_frame_enhancer.py
+++ b/tests/test_frame_enhancer.py
@@ -51,4 +51,4 @@ def test_load_model_uses_correct_name(monkeypatch):
     monkeypatch.setitem(sys.modules, 'torch', types.SimpleNamespace())
     importlib.reload(fe)
     fe._load_model('cpu')
-    assert recorded['name'] == 'swin2sr-lightweight-x4-128'
+    assert recorded['name'] == 'swin2sr-lightweight-x4-64'


### PR DESCRIPTION
## Summary
- fix default model name in `frame_enhancer`
- update tests for new model name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880dd2ff650832f9d791a27081470ab