### PR TITLE
Update Swin2SR model

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ make build
 
 ## Frame Enhancement CLI
 
-Enhance extracted frames using the Swin2SR model. Requires a CUDA-enabled GPU.
+Enhance extracted frames using the Swin2SR model
+(`caidas/swin2SR-realworld-sr-x4-64-bsrgan-psnr`, scale=4). Requires a CUDA-enabled GPU.
 
 ```
 python -m src.frame_enhancer --input-dir frames/ --output-dir frames_sr/ --batch-size 4

--- a/src/frame_enhancer.py
+++ b/src/frame_enhancer.py
@@ -28,6 +28,9 @@ except ImportError as exc:  # pragma: no cover - dependency missing
     
 from tqdm import tqdm
 
+MODEL_NAME = "caidas/swin2SR-realworld-sr-x4-64-bsrgan-psnr"
+SCALE = 4
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -60,7 +63,7 @@ def _load_model(device: str):
     import timm
     import torch
 
-    model = timm.create_model("swin2sr-lightweight-x4-64", pretrained=True)
+    model = timm.create_model(MODEL_NAME, pretrained=True, scale=SCALE)
 
     model = model.eval().to(device)
     return model

--- a/tests/test_frame_enhancer.py
+++ b/tests/test_frame_enhancer.py
@@ -35,8 +35,9 @@ def test_parse_args_defaults() -> None:
 def test_load_model_uses_correct_name(monkeypatch):
     recorded = {}
 
-    def fake_create_model(name, pretrained=True):
+    def fake_create_model(name, pretrained=True, scale=None):
         recorded['name'] = name
+        recorded['scale'] = scale
 
         class Dummy:
             def eval(self):
@@ -51,4 +52,5 @@ def test_load_model_uses_correct_name(monkeypatch):
     monkeypatch.setitem(sys.modules, 'torch', types.SimpleNamespace())
     importlib.reload(fe)
     fe._load_model('cpu')
-    assert recorded['name'] == 'swin2sr-lightweight-x4-64'
+    assert recorded['name'] == 'caidas/swin2SR-realworld-sr-x4-64-bsrgan-psnr'
+    assert recorded['scale'] == 4


### PR DESCRIPTION
## Summary
- switch frame enhancer to use model `caidas/swin2SR-realworld-sr-x4-64-bsrgan-psnr` with scale 4
- update tests for new model
- document updated model in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e4fe9178832f821b7c535b9a641c