### PR TITLE
Use HF hub path for Swin2SR model

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ make build
 ## Frame Enhancement CLI
 
 Enhance extracted frames using the Swin2SR model
-(`caidas/swin2SR-realworld-sr-x4-64-bsrgan-psnr`, scale=4). Requires a CUDA-enabled GPU.
+(`hf-hub:caidas/swin2SR-realworld-sr-x4-64-bsrgan-psnr`, scale=4).
+Requires a CUDA-enabled GPU.
 
 ```
 python -m src.frame_enhancer --input-dir frames/ --output-dir frames_sr/ --batch-size 4

--- a/src/frame_enhancer.py
+++ b/src/frame_enhancer.py
@@ -28,7 +28,7 @@ except ImportError as exc:  # pragma: no cover - dependency missing
     
 from tqdm import tqdm
 
-MODEL_NAME = "caidas/swin2SR-realworld-sr-x4-64-bsrgan-psnr"
+MODEL_NAME = "hf-hub:caidas/swin2SR-realworld-sr-x4-64-bsrgan-psnr"
 SCALE = 4
 
 LOGGER = logging.getLogger(__name__)

--- a/tests/test_frame_enhancer.py
+++ b/tests/test_frame_enhancer.py
@@ -52,5 +52,5 @@ def test_load_model_uses_correct_name(monkeypatch):
     monkeypatch.setitem(sys.modules, 'torch', types.SimpleNamespace())
     importlib.reload(fe)
     fe._load_model('cpu')
-    assert recorded['name'] == 'caidas/swin2SR-realworld-sr-x4-64-bsrgan-psnr'
+    assert recorded['name'] == 'hf-hub:caidas/swin2SR-realworld-sr-x4-64-bsrgan-psnr'
     assert recorded['scale'] == 4


### PR DESCRIPTION
## Summary
- load Swin2SR via `hf-hub:` prefix
- document HF hub model path
- update tests for new constant

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6880ed128198832fb8d80fff026a4d52