### PR TITLE
Add model-id CLI option for frame enhancer

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,11 @@ Enhance extracted frames using the Swin2SR model
 Requires a CUDA-enabled GPU.
 
 ```
-python -m src.frame_enhancer --input-dir frames/ --output-dir frames_sr/ --batch-size 4
+python -m src.frame_enhancer \
+    --input-dir frames/ \
+    --output-dir frames_sr/ \
+    --batch-size 4 \
+    --model-id hf-hub:caidas/swin2SR-realworld-sr-x4-64-bsrgan-psnr
 ```
 
 Before running the enhancement script, install the Python dependencies:

--- a/tests/test_frame_enhancer.py
+++ b/tests/test_frame_enhancer.py
@@ -31,6 +31,7 @@ def test_parse_args_defaults() -> None:
     args = fe.parse_args(["--input-dir", "in", "--output-dir", "out"])
     assert isinstance(args, argparse.Namespace)
     assert args.batch_size == 4
+    assert args.model_id == fe.DEFAULT_MODEL_ID
 
 def test_load_model_uses_correct_name(monkeypatch, tmp_path):
     recorded = {}
@@ -59,7 +60,7 @@ def test_load_model_uses_correct_name(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, 'huggingface_hub', types.SimpleNamespace(hf_hub_download=fake_hf_download))
     monkeypatch.setitem(sys.modules, 'torch', types.SimpleNamespace())
     importlib.reload(fe)
-    fe._load_model('cpu')
+    fe._load_model('cpu', fe.DEFAULT_MODEL_ID)
     assert recorded['name'] == 'swin'
     assert recorded['scale'] == 4
 
@@ -93,7 +94,7 @@ def test_load_model_with_missing_architecture(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, 'torch', types.SimpleNamespace())
 
     importlib.reload(fe)
-    fe._load_model('cpu')
+    fe._load_model('cpu', fe.DEFAULT_MODEL_ID)
 
     assert recorded['name'] == 'dummy_arch'
     assert recorded['scale'] == 4
@@ -129,7 +130,7 @@ def test_load_model_with_architectures_list(monkeypatch, tmp_path):
     monkeypatch.setitem(sys.modules, 'torch', types.SimpleNamespace())
 
     importlib.reload(fe)
-    fe._load_model('cpu')
+    fe._load_model('cpu', fe.DEFAULT_MODEL_ID)
 
     assert recorded['name'] == 'list_arch'
     assert recorded['scale'] == 4


### PR DESCRIPTION
## Summary
- allow specifying model repository path via `--model-id`
- support local or HF-hub model location in frame enhancer
- update tests for new argument
- document example usage in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6880fc3140fc832fac8763387678d969