### PR TITLE
Add FP16 option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,12 @@ python -m src.frame_enhancer \
     --input-dir frames/ \
     --output-dir frames_sr/ \
     --batch-size 4 \
-    --model-id caidas/swin2SR-realworld-sr-x4-64-bsrgan-psnr
+   --model-id caidas/swin2SR-realworld-sr-x4-64-bsrgan-psnr \
+   --fp16
 ```
+
+The `--fp16` flag converts the model and inputs to half precision,
+reducing memory usage on supported GPUs.
 
 If you encounter CUDA out-of-memory errors, reduce `--batch-size` or set the
 environment variable:


### PR DESCRIPTION
## Summary
- allow selecting FP16 precision with `--fp16` in `frame_enhancer`
- implement half precision handling in the enhancer
- document the option in the README
- test FP16 argument and model conversion

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68811d4f748c832f9a06540169d16355