### PR TITLE
Add YOLOX detection CLI

### DIFF
--- a/Dockerfile.detect
+++ b/Dockerfile.detect
@@ -1,0 +1,13 @@
+FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 python3-pip ffmpeg && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt yolox
+
+WORKDIR /app
+COPY . /app
+
+ENTRYPOINT ["python", "-m", "src.detect_objects"]

--- a/README.md
+++ b/README.md
@@ -72,3 +72,18 @@ python -m pip install -U -r requirements.txt
 Alternatively, build the Docker image which installs everything via `make build`.
 The Pillow and NumPy packages used by ``frame_enhancer.py`` come from
 ``requirements.txt``.
+
+## Object Detection CLI
+
+Run YOLOX object detection on extracted frames. Only ``person`` detections are
+saved to a JSON file.
+
+```bash
+python -m src.detect_objects \
+    --frames-dir frames/ \
+    --output-json detections.json \
+    --model yolox-s
+```
+
+See ``Dockerfile.detect`` for a GPU-enabled image containing the required
+dependencies.

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -1,0 +1,143 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Object detection on a directory of frames using YOLOX."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+from PIL import Image
+from tqdm import tqdm
+
+import torch
+from torchvision.transforms.functional import to_tensor
+
+LOGGER = logging.getLogger(__name__)
+
+YOLOX_MODELS = {"yolox-s", "yolox-m", "yolox-l", "yolox-x"}
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--frames-dir", type=Path, required=True, help="Directory of input frames"
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        required=True,
+        help="Path to write detections JSON",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="yolox-s",
+        choices=sorted(YOLOX_MODELS),
+        help="YOLOX model variant",
+    )
+    return parser.parse_args(argv)
+
+
+def _load_model(model_name: str, device: str = "cuda"):
+    """Load a YOLOX model via ``torch.hub``."""
+    if model_name not in YOLOX_MODELS:
+        raise ValueError(f"Unsupported model {model_name}")
+    LOGGER.info("Loading %s model on %s", model_name, device)
+    model = torch.hub.load(
+        "Megvii-BaseDetection/YOLOX", model_name, pretrained=True
+    )
+    model = model.eval().to(device)
+    return model
+
+
+def _preprocess_image(path: Path) -> torch.Tensor:
+    """Load image from ``path`` and convert to tensor."""
+    img = Image.open(path).convert("RGB")
+    tensor = to_tensor(img)
+    return tensor
+
+
+def _filter_person_detections(
+    outputs: torch.Tensor,
+) -> List[Tuple[List[float], float, int]]:
+    """Filter YOLOX detections to only ``person`` class."""
+    results = []
+    # YOLOX outputs: [x1, y1, x2, y2, score, class]
+    for det in outputs:
+        cls = int(det[5])
+        if cls != 0:
+            continue
+        bbox = det[:4].tolist()
+        score = float(det[4])
+        results.append((bbox, score, cls))
+    return results
+
+
+def detect_folder(frames_dir: Path, out_json: Path, model_name: str) -> None:
+    """Run detection over ``frames_dir`` and write results."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = _load_model(model_name, device)
+    frames = sorted(
+        [p for p in frames_dir.iterdir() if p.suffix.lower() in {".jpg", ".png"}]
+    )
+    if not frames:
+        LOGGER.warning("No frames found in %s", frames_dir)
+        return
+
+    out: List[dict] = []
+    start = time.perf_counter()
+    with tqdm(total=len(frames), desc="Detecting") as pbar:
+        for frame in frames:
+            tensor = _preprocess_image(frame).unsqueeze(0).to(device)
+            with torch.no_grad():
+                outputs = model(tensor)[0]
+            detections = [
+                {"bbox": b, "score": s, "class": c}
+                for b, s, c in _filter_person_detections(outputs)
+            ]
+            out.append({"frame": frame.name, "detections": detections})
+            pbar.update(1)
+    elapsed = time.perf_counter() - start
+
+    if device == "cuda":
+        free, total = torch.cuda.mem_get_info()
+        LOGGER.info(
+            "GPU memory: %.2f/%.2f GB used",
+            (total - free) / 1024 ** 3,
+            total / 1024 ** 3,
+        )
+    LOGGER.info("Processed %d frames in %.2fs", len(frames), elapsed)
+
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    with out_json.open("w") as f:
+        json.dump(out, f, indent=2)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """CLI entrypoint."""
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+    try:
+        detect_folder(args.frames_dir, args.output_json, args.model)
+    except Exception as exc:  # pragma: no cover - top level
+        LOGGER.error("Detection failed: %s", exc)
+        raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -1,0 +1,117 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`src.detect_objects`."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+import types
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+torch_stub = types.ModuleType("torch")
+torch_stub.cuda = types.SimpleNamespace(
+    is_available=lambda: False, mem_get_info=lambda: (0, 0)
+)
+torch_stub.hub = types.SimpleNamespace(load=lambda *a, **k: None)
+
+class _NoGrad:
+    def __enter__(self):
+        return None
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+torch_stub.no_grad = lambda: _NoGrad()
+sys.modules.setdefault("torch", torch_stub)
+
+tv_stub = types.ModuleType("torchvision")
+tv_transforms = types.ModuleType("torchvision.transforms")
+tv_transforms.functional = types.SimpleNamespace(to_tensor=lambda x: x)
+tv_stub.transforms = tv_transforms
+sys.modules.setdefault("torchvision", tv_stub)
+sys.modules.setdefault("torchvision.transforms", tv_transforms)
+sys.modules.setdefault("torchvision.transforms.functional", tv_transforms.functional)
+
+sys.modules.setdefault("PIL", types.ModuleType("PIL")).Image = object()
+class _DummyTqdm:
+    def __init__(self, *a, **k):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def update(self, n=1):
+        pass
+
+    def set_postfix(self, *a, **k):
+        pass
+
+sys.modules.setdefault("tqdm", types.ModuleType("tqdm")).tqdm = _DummyTqdm
+
+import src.detect_objects as dobj
+
+
+def test_parse_args_defaults() -> None:
+    args = dobj.parse_args([
+        "--frames-dir",
+        "frames",
+        "--output-json",
+        "out.json",
+    ])
+    assert isinstance(args, argparse.Namespace)
+    assert args.model == "yolox-s"
+
+
+def test_detect_folder_writes_json(tmp_path: Path, monkeypatch) -> None:
+    frames = tmp_path / "frames"
+    frames.mkdir()
+    (frames / "img1.jpg").write_bytes(b"\x00")
+    (frames / "img2.jpg").write_bytes(b"\x00")
+
+    class FakeDet(list):
+        def tolist(self):
+            return list(self)
+
+        def __getitem__(self, item):
+            res = super().__getitem__(item)
+            if isinstance(item, slice):
+                return FakeDet(res)
+            return res
+
+    class FakeModel:
+        def __call__(self, tensor):
+            return [[FakeDet([0.0, 0.0, 1.0, 1.0, 0.9, 0])]]
+
+    monkeypatch.setattr(dobj, "_load_model", lambda *a, **k: FakeModel())
+
+    class DummyTensor:
+        def unsqueeze(self, dim):
+            return self
+
+        def to(self, device):
+            return self
+
+    monkeypatch.setattr(dobj, "_preprocess_image", lambda p: DummyTensor())
+
+    out_json = tmp_path / "det.json"
+    dobj.detect_folder(frames, out_json, "yolox-s")
+
+    with out_json.open() as fh:
+        data = json.load(fh)
+    assert len(data) == 2
+    assert data[0]["detections"][0]["class"] == 0


### PR DESCRIPTION
## Summary
- implement `detect_objects` CLI for YOLOX inference
- add dedicated Dockerfile for detection
- document new CLI in README
- provide unit tests covering argument parsing and detection logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881efa61758832facf5feb11a79d6ce