### PR TITLE
Install loguru for YOLOX detection

### DIFF
--- a/Dockerfile.detect
+++ b/Dockerfile.detect
@@ -5,7 +5,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip3 install --no-cache-dir -r /tmp/requirements.txt yolox
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && \
+    pip3 install --no-cache-dir yolox
 
 WORKDIR /app
 COPY . /app

--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ that ``python`` and ``pip`` come from the same environment:
 python -m pip install -U -r requirements.txt
 ```
 
+The YOLOX models loaded via ``torch.hub`` also require the ``loguru`` package.
+Install it from ``requirements.txt`` or add ``loguru`` separately when running
+the detection CLI.
+
 Alternatively, build the Docker image which installs everything via `make build`.
 The Pillow and NumPy packages used by ``frame_enhancer.py`` come from
 ``requirements.txt``.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ accelerate>=0.23.0
 safetensors>=0.4.2
 pillow>=10.3
 numpy>=1.26
+loguru>=0.7


### PR DESCRIPTION
## Summary
- mention loguru requirement in README
- add loguru to requirements list
- fix YOLOX Docker install order

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881f5fe6d90832f824c5fd2b86bf75d