### PR TITLE
Fix YOLOX Docker build and add usage docs

### DIFF
--- a/Dockerfile.detect
+++ b/Dockerfile.detect
@@ -1,7 +1,13 @@
 FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
 
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 python3-pip ffmpeg && \
+    apt-get install -y --no-install-recommends \
+        python3 \
+        python3-pip \
+        ffmpeg \
+        cmake \
+        git \
+        build-essential && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt

--- a/README.md
+++ b/README.md
@@ -89,5 +89,20 @@ python -m src.detect_objects \
     --model yolox-s
 ```
 
-See ``Dockerfile.detect`` for a GPU-enabled image containing the required
-dependencies.
+To use the GPU-enabled Docker image, build it with ``Dockerfile.detect``:
+
+```bash
+docker build -f Dockerfile.detect -t decoder-detect:latest --progress=plain .
+```
+
+Run detection inside the container (assumes frames are in ``./frames``):
+
+```bash
+docker run --gpus all --rm -v $(pwd):/app decoder-detect:latest \
+    --frames-dir frames/ \
+    --output-json detections.json \
+    --model yolox-s
+```
+
+This image installs YOLOX and its dependencies, including ``cmake`` for
+building the model from source.


### PR DESCRIPTION
## Summary
- install cmake and build tools in Dockerfile.detect
- document building and running the detection Docker image

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68820f2e942c832f9dc76c03be027b2b