### PR TITLE
Fix YOLOX installation for detection Docker image

### DIFF
--- a/Dockerfile.detect
+++ b/Dockerfile.detect
@@ -12,7 +12,8 @@ RUN apt-get update && \
 
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && \
-    pip3 install --no-cache-dir yolox
+    pip3 install --no-cache-dir \
+        git+https://github.com/Megvii-BaseDetection/YOLOX.git
 
 WORKDIR /app
 COPY . /app

--- a/README.md
+++ b/README.md
@@ -105,4 +105,5 @@ docker run --gpus all --rm -v $(pwd):/app decoder-detect:latest \
 ```
 
 This image installs YOLOX and its dependencies, including ``cmake`` for
-building the model from source.
+building the model from source. The package is installed directly from the
+YOLOX GitHub repository to avoid issues with the PyPI release.


### PR DESCRIPTION
## Summary
- install YOLOX from GitHub in `Dockerfile.detect`
- update README about the new YOLOX install method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688214a411f8832f96a301ea9d7b5752