### PR TITLE
Fix YOLOX build failure

### DIFF
--- a/Dockerfile.detect
+++ b/Dockerfile.detect
@@ -4,6 +4,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         python3 \
         python3-pip \
+        python3-dev \
         ffmpeg \
         cmake \
         git \


### PR DESCRIPTION
## Summary
- add `python3-dev` to detection Dockerfile so YOLOX compiles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688216763c08832f85df291d9151530f