### PR TITLE
Add OpenCV requirement for detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ that ``python`` and ``pip`` come from the same environment:
 python -m pip install -U -r requirements.txt
 ```
 
-The YOLOX models loaded via ``torch.hub`` also require the ``loguru`` package.
-Install it from ``requirements.txt`` or add ``loguru`` separately when running
-the detection CLI.
+The YOLOX models loaded via ``torch.hub`` also require the ``loguru`` and
+``opencv-python-headless`` packages. Install them from ``requirements.txt`` or
+add them separately when running the detection CLI.
 
 Alternatively, build the Docker image which installs everything via `make build`.
 The Pillow and NumPy packages used by ``frame_enhancer.py`` come from

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ safetensors>=0.4.2
 pillow>=10.3
 numpy>=1.26
 loguru>=0.7
+opencv-python-headless>=4.8


### PR DESCRIPTION
## Summary
- install `opencv-python-headless` to satisfy YOLOX runtime
- update README setup instructions to mention OpenCV

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68821908aafc832f87a0c7a4195d0012