### PR TITLE
Fix detection Docker build with pytorch base

### DIFF
--- a/Dockerfile.detect
+++ b/Dockerfile.detect
@@ -1,10 +1,7 @@
-FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+FROM pytorch/pytorch:2.2.1-cuda12.1-cudnn8-runtime
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        python3 \
-        python3-pip \
-        python3-dev \
         ffmpeg \
         cmake \
         git \

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ docker run --gpus all --rm -v $(pwd):/app decoder-detect:latest \
     --model yolox-s
 ```
 
-This image installs YOLOX and its dependencies, including ``cmake`` for
-building the model from source. The package is installed directly from the
-YOLOX GitHub repository to avoid issues with the PyPI release.
+This image installs YOLOX and its dependencies using the official
+``pytorch/pytorch`` CUDA runtime as the base image, which already includes
+PyTorch with GPU support. The YOLOX package is installed directly from the
+GitHub repository to avoid issues with the PyPI release.


### PR DESCRIPTION
## Summary
- use the official PyTorch CUDA runtime as the base for `Dockerfile.detect`
- update README with new Dockerfile details

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68821b63d4a4832f990688c5f89dba54