### PR TITLE
Fix missing tabulate dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,10 @@ that ``python`` and ``pip`` come from the same environment:
 python -m pip install -U -r requirements.txt
 ```
 
-The YOLOX models loaded via ``torch.hub`` also require the ``loguru`` package
-and OpenCV. Both ``loguru`` and ``opencv-python-headless`` are included in
-``requirements.txt``. Install them or add the packages separately when running
-the detection CLI.
+The YOLOX models loaded via ``torch.hub`` also require the ``loguru`` package,
+OpenCV, and ``tabulate``. These dependencies are included in
+``requirements.txt`` (``loguru``, ``opencv-python-headless``, ``tabulate``). If
+installing individually, add these packages before running the detection CLI.
 
 Alternatively, build the Docker image which installs everything via `make build`.
 The Pillow and NumPy packages used by ``frame_enhancer.py`` come from

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pillow>=10.3
 numpy>=1.26
 loguru>=0.7
 opencv-python-headless>=4.10
+tabulate>=0.9


### PR DESCRIPTION
## Summary
- add `tabulate` to requirements
- document additional YOLOX dependency in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688220b511ec832fae31839fa2841c38