### PR TITLE
Fix YOLOX detection size mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ saved to a JSON file.
 python -m src.detect_objects \
     --frames-dir frames/ \
     --output-json detections.json \
-    --model yolox-s
+    --model yolox-s \
+    --img-size 640
 ```
 
 To use the GPU-enabled Docker image, build it with ``Dockerfile.detect``:
@@ -102,7 +103,8 @@ Run detection inside the container (assumes frames are in ``./frames``):
 docker run --gpus all --rm -v $(pwd):/app decoder-detect:latest \
     --frames-dir frames/ \
     --output-json detections.json \
-    --model yolox-s
+    --model yolox-s \
+    --img-size 640
 ```
 
 This image installs YOLOX and its dependencies using the official

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -75,6 +75,7 @@ def test_parse_args_defaults() -> None:
     ])
     assert isinstance(args, argparse.Namespace)
     assert args.model == "yolox-s"
+    assert args.img_size == 640
 
 
 def test_load_model_translates_hyphen(monkeypatch) -> None:
@@ -131,10 +132,10 @@ def test_detect_folder_writes_json(tmp_path: Path, monkeypatch) -> None:
         def to(self, device):
             return self
 
-    monkeypatch.setattr(dobj, "_preprocess_image", lambda p: DummyTensor())
+    monkeypatch.setattr(dobj, "_preprocess_image", lambda p, s: DummyTensor())
 
     out_json = tmp_path / "det.json"
-    dobj.detect_folder(frames, out_json, "yolox-s")
+    dobj.detect_folder(frames, out_json, "yolox-s", 640)
 
     with out_json.open() as fh:
         data = json.load(fh)


### PR DESCRIPTION
## Summary
- add `--img-size` argument to detection CLI and resize frames before inference
- update tests for detection CLI
- document the new option in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882267a7be0832fb6a9fc28f5ccfc10