### PR TITLE
Add ROI viewer CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,17 @@ This image installs YOLOX and its dependencies using the official
 ``pytorch/pytorch`` CUDA runtime as the base image, which already includes
 PyTorch with GPU support. The YOLOX package is installed directly from the
 GitHub repository to avoid issues with the PyPI release.
+
+## ROI Visualization CLI
+
+Overlay detection bounding boxes on extracted frames.
+
+```bash
+python -m src.draw_roi \
+    --frames-dir frames/ \
+    --detections-json detections.json \
+    --output-dir frames_roi/
+```
+
+The command reads detection results from ``detections.json`` and writes
+annotated images to ``frames_roi`` using red rectangles by default.

--- a/src/draw_roi.py
+++ b/src/draw_roi.py
@@ -1,0 +1,117 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Draw ROI detections on frame images."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Iterable, List
+
+from PIL import Image, ImageDraw
+
+LOGGER = logging.getLogger(__name__)
+
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--frames-dir",
+        type=Path,
+        required=True,
+        help="Directory containing input frame images.",
+    )
+    parser.add_argument(
+        "--detections-json",
+        type=Path,
+        required=True,
+        help="JSON file with detection data from detect_objects",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Where annotated frames will be written",
+    )
+    parser.add_argument(
+        "--color",
+        type=str,
+        default="red",
+        help="Rectangle outline color (default: red)",
+    )
+    return parser.parse_args(argv)
+
+
+
+def _load_detections(path: Path) -> List[dict]:
+    """Load detection list from ``path``."""
+    with path.open() as fh:
+        data = json.load(fh)
+    if not isinstance(data, list):
+        raise ValueError("Invalid detections format")
+    return data
+
+
+
+def draw_rois(frames_dir: Path, detections_json: Path, output_dir: Path, color: str = "red") -> None:
+    """Overlay detection ROIs on frames and save to ``output_dir``.
+
+    Args:
+        frames_dir: Directory of frame images.
+        detections_json: JSON file with detection results.
+        output_dir: Destination for annotated images.
+        color: Outline color for rectangles.
+    """
+    detections = _load_detections(detections_json)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for entry in detections:
+        frame_name = entry.get("frame")
+        rois = [det.get("bbox") for det in entry.get("detections", [])]
+        if not frame_name:
+            LOGGER.debug("Skipping detection entry without frame")
+            continue
+        frame_path = frames_dir / frame_name
+        if not frame_path.exists():
+            LOGGER.warning("Frame not found: %s", frame_path)
+            continue
+        img = Image.open(frame_path).convert("RGB")
+        draw = ImageDraw.Draw(img)
+        for bbox in rois:
+            if not isinstance(bbox, list) or len(bbox) != 4:
+                LOGGER.debug("Invalid bbox %s in %s", bbox, frame_name)
+                continue
+            x1, y1, x2, y2 = bbox
+            draw.rectangle([x1, y1, x2, y2], outline=color, width=2)
+        out_path = output_dir / frame_name
+        img.save(out_path)
+        LOGGER.debug("Wrote %s", out_path)
+
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """CLI entrypoint."""
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+    try:
+        draw_rois(args.frames_dir, args.detections_json, args.output_dir, args.color)
+    except Exception as exc:  # pragma: no cover - top level
+        LOGGER.error("Failed to draw ROIs: %s", exc)
+        raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_draw_roi.py
+++ b/tests/test_draw_roi.py
@@ -1,0 +1,96 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`src.draw_roi`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import sys
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import pytest
+
+
+class DummyImage:
+    def __init__(self, path: str | None = None):
+        self.path = Path(path) if path else None
+
+    def convert(self, mode: str):
+        return self
+
+    def save(self, path: str | Path) -> None:
+        Path(path).write_bytes(b"img")
+
+    @staticmethod
+    def open(path: str | Path):
+        return DummyImage(str(path))
+
+    @staticmethod
+    def new(mode: str, size: tuple[int, int]):
+        return DummyImage()
+
+
+class DummyDraw:
+    def __init__(self, img: DummyImage):
+        self.img = img
+
+    def rectangle(self, *args, **kwargs):
+        pass
+
+
+pil_mod = types.ModuleType("PIL")
+pil_mod.__path__ = []  # treat as package
+pil_image_mod = types.ModuleType("PIL.Image")
+pil_image_mod.open = DummyImage.open
+pil_image_mod.new = DummyImage.new
+pil_image_mod.Image = DummyImage
+pil_draw_mod = types.ModuleType("PIL.ImageDraw")
+pil_draw_mod.Draw = DummyDraw
+pil_mod.Image = DummyImage
+pil_mod.ImageDraw = pil_draw_mod
+sys.modules["PIL"] = pil_mod
+sys.modules["PIL.Image"] = pil_image_mod
+sys.modules["PIL.ImageDraw"] = pil_draw_mod
+
+from PIL import Image  # type: ignore
+
+import src.draw_roi as dr
+
+
+def test_parse_args_defaults() -> None:
+    args = dr.parse_args([
+        "--frames-dir",
+        "frames",
+        "--detections-json",
+        "det.json",
+        "--output-dir",
+        "out",
+    ])
+    assert args.color == "red"
+
+
+def test_draw_rois_writes_files(tmp_path: Path) -> None:
+    frames = tmp_path / "frames"
+    frames.mkdir()
+    img_path = frames / "img1.jpg"
+    Image.new("RGB", (10, 10)).save(img_path)
+    det_json = tmp_path / "det.json"
+    det_json.write_text('[{"frame": "img1.jpg", "detections": [{"bbox": [1, 1, 5, 5]}]}]')
+
+    out_dir = tmp_path / "out"
+    dr.draw_rois(frames, det_json, out_dir, color="blue")
+
+    out_img = out_dir / "img1.jpg"
+    assert out_img.exists(), "Annotated image was not created"


### PR DESCRIPTION
## Summary
- implement `draw_roi.py` CLI to overlay detection boxes
- document ROI visualization workflow in README
- add tests for ROI viewer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68822bd6f608832f8e6622dc06977e1d