### PR TITLE
Fix ROI drawing with reversed bbox coords

### DIFF
--- a/tests/test_draw_roi.py
+++ b/tests/test_draw_roi.py
@@ -94,3 +94,19 @@ def test_draw_rois_writes_files(tmp_path: Path) -> None:
 
     out_img = out_dir / "img1.jpg"
     assert out_img.exists(), "Annotated image was not created"
+
+
+def test_draw_rois_sanitizes_bbox(tmp_path: Path) -> None:
+    frames = tmp_path / "frames"
+    frames.mkdir()
+    img_path = frames / "img1.jpg"
+    Image.new("RGB", (10, 10)).save(img_path)
+    det_json = tmp_path / "det.json"
+    det_json.write_text('[{"frame": "img1.jpg", "detections": [{"bbox": [5, 5, 1, 1]}]}]')
+
+    out_dir = tmp_path / "out"
+    # Should not raise even though bbox coordinates are reversed
+    dr.draw_rois(frames, det_json, out_dir)
+
+    out_img = out_dir / "img1.jpg"
+    assert out_img.exists(), "Annotated image was not created"


### PR DESCRIPTION
## Summary
- ensure bbox coords are sorted before drawing
- test handling of reversed bbox

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68822e4d2370832f83b2bdf25a0d3f19