### PR TITLE
Fix YOLOX bbox scaling

### DIFF
--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -145,7 +145,7 @@ def test_detect_folder_writes_json(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(
         dobj,
         "_preprocess_image",
-        lambda p, s: (DummyTensor(), 1.0, 0, 0, 10, 10),
+        lambda p, s: (DummyTensor(), 10, 10),
     )
 
     out_json = tmp_path / "det.json"


### PR DESCRIPTION
## Summary
- stop double deletterboxing by trusting YOLOX outputs
- simplify preprocessing return values
- add sanity check for bbox range
- update test expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882362c5e18832fae5093155f2ba763