### PR TITLE
Fix ROI scaling after YOLOX letterbox

### DIFF
--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -145,7 +145,7 @@ def test_detect_folder_writes_json(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(
         dobj,
         "_preprocess_image",
-        lambda p, s: (DummyTensor(), 10, 10),
+        lambda p, s: (DummyTensor(), 1.0, 0, 0, 10, 10),
     )
 
     out_json = tmp_path / "det.json"


### PR DESCRIPTION
## Summary
- restore returning resize metadata from `_preprocess_image`
- convert YOLOX outputs back to original frame coordinates
- update tests for new return signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688238ceebc8832fb6da2ad9d565e45a