### PR TITLE
Handle int strides in YOLOX decode

### DIFF
--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -165,7 +165,11 @@ def _decode_gpu(head: object, outs: torch.Tensor) -> torch.Tensor:
     for attr in ("grids", "expanded_strides", "strides"):
         buf = getattr(head, attr, None)
         if isinstance(buf, list):
-            setattr(head, attr, [t.cuda() for t in buf])
+            setattr(
+                head,
+                attr,
+                [t.cuda() if hasattr(t, "cuda") else t for t in buf],
+            )
         elif hasattr(buf, "cuda"):
             setattr(head, attr, buf.cuda())
 


### PR DESCRIPTION
## Summary
- fix `_decode_gpu` for YOLOX models where stride buffers may be integers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882736d82e8832f8bcbc81ab1becab1