### PR TITLE
Fix YOLOX decode buffer sync

### DIFF
--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -95,6 +95,10 @@ def test_decode_gpu_moves_buffers() -> None:
             self.device = device
             self.dtype = "float32"
 
+        def cpu(self):
+            self.device = "cpu"
+            return self
+
         def cuda(self):
             self.device = "cuda"
             return self
@@ -113,6 +117,8 @@ def test_decode_gpu_moves_buffers() -> None:
     assert decoded == [out]
     assert head.grids[0].device == "cuda"
     assert head.expanded_strides[0].device == "cuda"
+    assert getattr(head, "_buffers_synced", False)
+    assert out.device == "cuda"
 
 
 def test_detect_folder_writes_json(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- avoid CPU/GPU mismatch when running YOLOX detection by syncing head buffers
- update test to cover new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68827800101c832fa76fbbe305edf60b