### PR TITLE
Handle YOLOX single-image output

### DIFF
--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -191,6 +191,13 @@ def detect_folder(
             tensor = tensor.unsqueeze(0).cuda()
             with torch.no_grad():
                 raw = model(tensor)[0]
+
+            # Align output tensor with expected (B, N, 85) shape.
+            if isinstance(raw, list):
+                raw = model.head.decode_outputs(raw, dtype=raw[0].dtype)
+            elif raw.dim() == 2:
+                raw = raw.unsqueeze(0)
+
             outputs = raw
             from yolox.utils import postprocess
 

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -221,7 +221,7 @@ def test_detect_folder_uses_decode(monkeypatch, tmp_path: Path) -> None:
     out_json = tmp_path / "det.json"
     dobj.detect_folder(frames, out_json, "yolox-s", 640)
 
-    assert not head.called
+    assert head.called
     with out_json.open() as fh:
         data = json.load(fh)
     assert data and data[0]["detections"]


### PR DESCRIPTION
## Summary
- fix YOLOX detection when model returns (N, 85) tensor
- adjust unit test expectation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688282c562b0832f88c3f04a030dfa58