### PR TITLE
Fix YOLOX no-detection case

### DIFF
--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -208,11 +208,9 @@ def detect_folder(
                 nms_thre=nms_thres,
                 class_agnostic=False,
             )
-            if processed:
-                det = processed[0]
-                outputs_list = det.cpu().tolist()
-            else:
-                outputs_list = []
+
+            det = processed[0] if processed and processed[0] is not None else None
+            outputs_list = det.cpu().tolist() if det is not None else []
 
             detections = []
             for bbox, score, cls in _filter_detections(outputs_list, conf_thres):


### PR DESCRIPTION
## Summary
- avoid calling `.cpu()` on `None` in `detect_objects`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688283d5c754832fa1b715811e6723b2