### PR TITLE
Add YOLOX single image detection demo

### DIFF
--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -1,0 +1,18 @@
+FROM pytorch/pytorch:2.2.1-cuda12.1-cudnn8-runtime
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ffmpeg \
+        cmake \
+        git \
+        build-essential && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && \
+    pip3 install --no-cache-dir git+https://github.com/Megvii-BaseDetection/YOLOX.git
+
+WORKDIR /app
+COPY . /app
+
+ENTRYPOINT ["python", "-m", "src.detect_image"]

--- a/README.md
+++ b/README.md
@@ -139,3 +139,27 @@ python -m src.validate_detections sanity-check \
 ```
 
 This prints the number of invalid bounding boxes and low-confidence detections.
+
+## Single Image Detection Demo
+
+A small container is provided to run YOLOX on a single image. Build it with:
+
+```bash
+docker build -f Dockerfile.image -t decoder-image:latest .
+```
+
+Run detection on ``frame_000019.jpg`` using the GPU:
+
+```bash
+docker run --gpus all --rm -v $(pwd):/app decoder-image:latest \
+    --image /app/frames01/frame_000019.jpg \
+    --model yolox-x \
+    --conf-thres 0.10 \
+    --nms-thres 0.45 \
+    --img-size 640 \
+    --device gpu \
+    --save-result /app/out.jpg
+```
+
+The command prints the detections as JSON and saves the annotated image to
+``out.jpg``.

--- a/src/detect_image.py
+++ b/src/detect_image.py
@@ -1,0 +1,146 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Single image detection demo using YOLOX."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from typing import Iterable, List, Dict
+
+import torch
+from PIL import Image, ImageDraw
+
+from . import detect_objects as dobj
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _load_model_device(model_name: str, device: torch.device):
+    """Load a YOLOX model on the specified device."""
+    if model_name not in dobj.YOLOX_MODELS:
+        raise ValueError(f"Unsupported model {model_name}")
+    torch_name = dobj._YOLOX_MODEL_MAP[model_name]
+    LOGGER.info("Loading %s on %s", model_name, device)
+    model = torch.hub.load("Megvii-BaseDetection/YOLOX", torch_name, pretrained=True)
+    return model.eval().to(device)
+
+
+def _annotate(image_path: Path, detections: List[Dict], output: Path) -> None:
+    """Draw detections on the image and save to ``output``."""
+    img = Image.open(image_path).convert("RGB")
+    draw = ImageDraw.Draw(img)
+    for det in detections:
+        x1, y1, x2, y2 = det["bbox"]
+        draw.rectangle([x1, y1, x2, y2], outline="red", width=2)
+    img.save(output)
+
+
+def detect_image(
+    image_path: Path,
+    model_name: str,
+    img_size: int,
+    conf_thres: float,
+    nms_thres: float,
+    device: torch.device,
+) -> List[Dict]:
+    """Run YOLOX detection on ``image_path``."""
+    model = _load_model_device(model_name, device)
+    tensor, ratio, pad_x, pad_y, w0, h0 = dobj._preprocess_image(image_path, img_size)
+    tensor = tensor.unsqueeze(0).to(device)
+    with torch.no_grad():
+        raw = model(tensor)[0]
+    if isinstance(raw, list):
+        raw = model.head.decode_outputs(raw, dtype=raw[0].dtype)
+    elif raw.dim() == 2:
+        raw = raw.unsqueeze(0)
+    from yolox.utils import postprocess
+
+    processed = postprocess(
+        raw,
+        num_classes=80,
+        conf_thre=conf_thres,
+        nms_thre=nms_thres,
+        class_agnostic=False,
+    )
+    det = processed[0] if processed and processed[0] is not None else None
+    outputs_list = det.cpu().tolist() if det is not None else []
+
+    detections: List[Dict] = []
+    for bbox, score, cls in dobj._filter_detections(outputs_list, conf_thres):
+        x0 = max((bbox[0] - pad_x) / ratio, 0.0)
+        y0 = max((bbox[1] - pad_y) / ratio, 0.0)
+        x1 = min((bbox[2] - pad_x) / ratio, w0)
+        y1 = min((bbox[3] - pad_y) / ratio, h0)
+        ix0, iy0, ix1, iy1 = (
+            int(round(x0)),
+            int(round(y0)),
+            int(round(x1)),
+            int(round(y1)),
+        )
+        if ix1 > ix0 and iy1 > iy0:
+            detections.append(
+                {"bbox": [ix0, iy0, ix1, iy1], "score": score, "class": cls}
+            )
+    return detections
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--image", type=Path, required=True, help="Path to input image")
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="yolox-s",
+        choices=sorted(dobj.YOLOX_MODELS),
+        help="YOLOX model variant",
+    )
+    parser.add_argument("--img-size", type=int, default=640, help="Resize square size")
+    parser.add_argument("--conf-thres", type=float, default=0.3, help="Confidence threshold")
+    parser.add_argument("--nms-thres", type=float, default=0.45, help="NMS IoU threshold")
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="gpu" if torch.cuda.is_available() else "cpu",
+        help="Device to run inference on (cpu or gpu)",
+    )
+    parser.add_argument("--save-result", type=Path, help="Where to save annotated image")
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    """CLI entrypoint."""
+    args = parse_args(argv)
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s")
+    device = torch.device("cuda" if args.device.lower() in {"gpu", "cuda"} else "cpu")
+    try:
+        detections = detect_image(
+            args.image,
+            args.model,
+            args.img_size,
+            args.conf_thres,
+            args.nms_thres,
+            device,
+        )
+        if args.save_result:
+            _annotate(args.image, detections, args.save_result)
+        print(json.dumps({"image": args.image.name, "detections": detections}, indent=2))
+    except Exception as exc:  # pragma: no cover - top level error
+        LOGGER.exception("Detection failed")
+        raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_detect_image.py
+++ b/tests/test_detect_image.py
@@ -1,0 +1,100 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`src.detect_image`."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import types
+from pathlib import Path
+import contextlib
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide minimal torch and PIL stubs before importing the module
+torch_mod = types.ModuleType("torch")
+torch_mod.cuda = types.SimpleNamespace(is_available=lambda: True)
+torch_mod.hub = types.SimpleNamespace(load=lambda *a, **k: None)
+torch_mod.device = lambda x: x
+torch_mod.no_grad = contextlib.nullcontext
+sys.modules.setdefault("torch", torch_mod)
+tv_mod = types.ModuleType("torchvision")
+transforms_mod = types.ModuleType("torchvision.transforms")
+functional_mod = types.ModuleType("torchvision.transforms.functional")
+functional_mod.to_tensor = lambda img: img
+transforms_mod.functional = functional_mod
+tv_mod.transforms = transforms_mod
+sys.modules.setdefault("torchvision", tv_mod)
+sys.modules.setdefault("torchvision.transforms", transforms_mod)
+sys.modules.setdefault("torchvision.transforms.functional", functional_mod)
+sys.modules.setdefault("tqdm", types.ModuleType("tqdm")).tqdm = lambda *a, **k: a[0] if a else None
+pil_mod = types.ModuleType("PIL")
+pil_mod.__path__ = []
+pil_image_mod = types.ModuleType("PIL.Image")
+pil_draw_mod = types.ModuleType("PIL.ImageDraw")
+pil_image_mod.open = lambda p: None
+pil_draw_mod.Draw = lambda img: None
+pil_mod.Image = object
+pil_mod.ImageDraw = pil_draw_mod
+sys.modules.setdefault("PIL", pil_mod)
+sys.modules.setdefault("PIL.Image", pil_image_mod)
+sys.modules.setdefault("PIL.ImageDraw", pil_draw_mod)
+
+import src.detect_image as di
+
+
+def test_parse_args_defaults() -> None:
+    args = di.parse_args(["--image", "img.jpg"])
+    assert isinstance(args, argparse.Namespace)
+    assert args.model == "yolox-s"
+    assert args.img_size == 640
+
+
+def test_detect_image(monkeypatch) -> None:
+    class DummyTensor:
+        def unsqueeze(self, dim):
+            return self
+
+        def to(self, device):
+            return self
+
+    class FakeDet(list):
+        dtype = "float32"
+
+        def tolist(self):
+            return [list(self)]
+
+        def cpu(self):
+            return self
+
+    class FakeModel:
+        head = types.SimpleNamespace(decode_outputs=lambda out, dtype: out)
+
+        def __call__(self, tensor):
+            return [[FakeDet([0.0, 0.0, 1.0, 1.0, 0.9, 0])]]
+
+    monkeypatch.setattr(di, "_load_model_device", lambda *a, **k: FakeModel())
+    monkeypatch.setattr(di.dobj, "_preprocess_image", lambda *a, **k: (DummyTensor(), 1.0, 0, 0, 10, 10))
+    utils_mod = types.ModuleType("utils")
+    utils_mod.postprocess = lambda outputs, num_classes, conf_thre, nms_thre, class_agnostic=False: [FakeDet([0.0, 0.0, 1.0, 1.0, 0.9, 0])]
+    sys.modules["yolox"] = types.ModuleType("yolox")
+    sys.modules["yolox.utils"] = utils_mod
+
+    detections = di.detect_image(Path("img.jpg"), "yolox-s", 640, 0.1, 0.45, device="cpu")
+
+    assert detections
+    assert detections[0]["class"] == 0
+
+    sys.modules.pop("yolox.utils", None)
+    sys.modules.pop("yolox", None)
+


### PR DESCRIPTION
## Summary
- add `src.detect_image` for single-image YOLOX inference
- provide `Dockerfile.image` container entrypoint
- document usage in README
- add unit test for new module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a7d10388832f87d4da0396b84064