### PR TITLE
Fix YOLOX preprocessing

### DIFF
--- a/src/detect_image.py
+++ b/src/detect_image.py
@@ -58,7 +58,6 @@ def detect_image(
     """Run YOLOX detection on ``image_path``."""
     model = _load_model_device(model_name, device)
     tensor, ratio, pad_x, pad_y, w0, h0 = dobj._preprocess_image(image_path, img_size)
-    tensor = tensor.unsqueeze(0).to(device)
     with torch.no_grad():
         raw = model(tensor)[0]
     if isinstance(raw, list):


### PR DESCRIPTION
## Summary
- update YOLOX `_preprocess_image` to mirror official demo
- move tensor creation to GPU during preprocessing
- simplify callers in `detect_objects` and `detect_image`
- correct scaling ratio for YOLOX images

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68833c1a9dc8832fadbd4fde64607823