### PR TITLE
Fix ROI back-projection

### DIFF
--- a/src/draw_roi.py
+++ b/src/draw_roi.py
@@ -90,32 +90,64 @@ def _sanitize_bbox(bbox: List[float]) -> Tuple[float, float, float, float]:
 
 
 def _preprocess_params(img: Any, size: int) -> Tuple[float, float, float, int, int]:
-    """Compute scaling parameters using YOLOX ``ValTransform``.
+    """Compute resize ratio and padding for ``img``.
+
+    This replicates the behaviour of YOLOX :class:`ValTransform` used in
+    :mod:`src.detect_objects`. The function does not require the YOLOX package
+    and therefore allows drawing ROIs in environments where YOLOX is not
+    installed.
 
     Args:
-        img: Image array in BGR format.
+        img: Image array in ``BGR`` format.
         size: Target square size for inference.
 
     Returns:
-        Tuple of ``(ratio, pad_x, pad_y, width, height)`` describing the
-        resize ratio, horizontal padding, vertical padding and original
-        dimensions.
+        A tuple ``(ratio, pad_x, pad_y, width, height)`` with the resize ratio,
+        horizontal padding, vertical padding and the original dimensions.
     """
-
-    from yolox.data.data_augment import ValTransform
 
     h0, w0 = img.shape[:2]
 
-    preproc = ValTransform(legacy=False)
-    processed, _ = preproc(img, None, (size, size))
-
-    _, new_h, new_w = processed.shape
+    scale = min(size / w0, size / h0)
+    new_w = int(w0 * scale)
+    new_h = int(h0 * scale)
     pad_x = (size - new_w) / 2
     pad_y = (size - new_h) / 2
 
     ratio = new_w / w0
 
     return ratio, pad_x, pad_y, w0, h0
+
+
+def _backproject_bbox(
+    bbox: Tuple[float, float, float, float],
+    ratio: float,
+    pad_x: float,
+    pad_y: float,
+    width: int,
+    height: int,
+) -> Tuple[int, int, int, int]:
+    """Project ``bbox`` from model coordinates to the original image.
+
+    Args:
+        bbox: Bounding box ``(x1, y1, x2, y2)`` from the model output.
+        ratio: Resize ratio used during preprocessing.
+        pad_x: Horizontal padding used during preprocessing.
+        pad_y: Vertical padding used during preprocessing.
+        width: Original image width.
+        height: Original image height.
+
+    Returns:
+        Integer bounding box coordinates in the original image space.
+    """
+
+    x1, y1, x2, y2 = bbox
+    x1 = max(int(round((x1 - pad_x) / ratio)), 0)
+    y1 = max(int(round((y1 - pad_y) / ratio)), 0)
+    x2 = min(int(round((x2 - pad_x) / ratio)), width)
+    y2 = min(int(round((y2 - pad_y) / ratio)), height)
+
+    return x1, y1, x2, y2
 
 
 def _color_bgr(name: str) -> Tuple[int, int, int]:
@@ -176,10 +208,9 @@ def draw_rois(
                 LOGGER.debug("Invalid bbox %s in %s", bbox, frame_name)
                 continue
             x1, y1, x2, y2 = _sanitize_bbox(bbox)
-            x1 = max(int(round((x1 - pad_x) / ratio)), 0)
-            y1 = max(int(round((y1 - pad_y) / ratio)), 0)
-            x2 = min(int(round((x2 - pad_x) / ratio)), w0)
-            y2 = min(int(round((y2 - pad_y) / ratio)), h0)
+            x1, y1, x2, y2 = _backproject_bbox(
+                (x1, y1, x2, y2), ratio, pad_x, pad_y, w0, h0
+            )
 
             if x2 > x1 and y2 > y1:
                 cv2.rectangle(img, (x1, y1), (x2, y2), bgr, 2)

--- a/tests/test_draw_roi.py
+++ b/tests/test_draw_roi.py
@@ -101,3 +101,8 @@ def test_draw_rois_sanitizes_bbox(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     dr.draw_rois(frames, det_json, out_dir, 640)
 
     assert (out_dir / "img.jpg").exists()
+
+
+def test_backproject_bbox() -> None:
+    bbox = dr._backproject_bbox((1.0, 1.0, 5.0, 5.0), 0.5, 1.0, 1.0, 10, 10)
+    assert bbox == (0, 0, 8, 8)


### PR DESCRIPTION
## Summary
- update ROI back-projection logic to match preprocessing
- avoid YOLOX dependency for drawing
- unit test `_backproject_bbox`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688354f7953c832fa0f97c661ca5a448