### PR TITLE
Simplify ROI drawing

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,9 @@ python -m src.draw_roi \
 ```
 
 The command reads detection results from ``detections.json`` and writes
-annotated images to ``frames_roi`` using red rectangles by default.
+annotated images to ``frames_roi`` using red rectangles by default. The
+bounding box coordinates are expected to match the original frame pixels,
+so no scaling is applied when drawing.
 
 ## Detection Validation CLI
 

--- a/src/draw_roi.py
+++ b/src/draw_roi.py
@@ -177,7 +177,7 @@ def draw_rois(
         frames_dir: Directory of frame images.
         detections_json: JSON file with detection results.
         output_dir: Destination for annotated images.
-        img_size: Square size used during detection preprocessing.
+        img_size: Unused. Present for backwards compatibility.
         color: Outline color for rectangles.
     """
     detections = _load_detections(detections_json)
@@ -201,16 +201,11 @@ def draw_rois(
             LOGGER.warning("Failed to read %s", frame_path)
             continue
 
-        ratio, pad_x, pad_y, w0, h0 = _preprocess_params(img, img_size)
-
         for bbox in rois:
             if not isinstance(bbox, list) or len(bbox) != 4:
                 LOGGER.debug("Invalid bbox %s in %s", bbox, frame_name)
                 continue
-            x1, y1, x2, y2 = _sanitize_bbox(bbox)
-            x1, y1, x2, y2 = _backproject_bbox(
-                (x1, y1, x2, y2), ratio, pad_x, pad_y, w0, h0
-            )
+            x1, y1, x2, y2 = map(int, _sanitize_bbox(bbox))
 
             if x2 > x1 and y2 > y1:
                 cv2.rectangle(img, (x1, y1), (x2, y2), bgr, 2)

--- a/tests/test_draw_roi.py
+++ b/tests/test_draw_roi.py
@@ -69,7 +69,6 @@ def test_parse_args_defaults() -> None:
 
 def test_draw_rois_writes_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     dummy_cv2 = _setup_cv2(monkeypatch)
-    monkeypatch.setattr(dr, "_preprocess_params", lambda img, size: (1.0, 0.0, 0.0, 10, 10))
 
     frames = tmp_path / "frames"
     frames.mkdir()
@@ -88,7 +87,6 @@ def test_draw_rois_writes_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
 
 def test_draw_rois_sanitizes_bbox(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _setup_cv2(monkeypatch)
-    monkeypatch.setattr(dr, "_preprocess_params", lambda img, size: (1.0, 0.0, 0.0, 10, 10))
 
     frames = tmp_path / "frames"
     frames.mkdir()


### PR DESCRIPTION
## Summary
- remove scaling logic from ROI overlay
- adjust tests accordingly
- clarify README that bounding boxes are already in frame pixel space

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68835cce7a48832f961e138276d1f4b0