### PR TITLE
Add class filtering option to YOLOX CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ The Pillow and NumPy packages used by ``frame_enhancer.py`` come from
 
 ## Object Detection CLI
 
-Run YOLOX object detection on extracted frames. Only ``person`` detections are
-saved. A CUDA-enabled GPU and YOLOX ``v0.3`` or newer are required.
+Run YOLOX object detection on extracted frames. A CUDA-enabled GPU and YOLOX
+``v0.3`` or newer are required. The ``--classes`` option controls which object
+categories to keep (default: ``person racket ball``).
 
 ```bash
 python -m src.detect_objects \
@@ -95,7 +96,8 @@ python -m src.detect_objects \
     --model yolox-s \
     --img-size 640 \
     --conf-thres 0.30 \
-    --nms-thres 0.45
+    --nms-thres 0.45 \
+    --classes person ball
 ```
 
 To use the GPU-enabled Docker image, build it with ``Dockerfile.detect``:
@@ -113,7 +115,8 @@ docker run --gpus all --rm -v $(pwd):/app decoder-detect:latest \
     --model yolox-s \
     --img-size 640 \
     --conf-thres 0.30 \
-    --nms-thres 0.45
+    --nms-thres 0.45 \
+    --classes person ball
 ```
 
 Example ``detections.json`` output:

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -60,6 +60,7 @@ def test_parse_args_defaults() -> None:
     assert isinstance(args, argparse.Namespace)
     assert args.model == "yolox-s"
     assert args.img_size == 640
+    assert args.classes == ["person", "racket", "ball"]
 
 
 def test_load_model_translates_hyphen(monkeypatch) -> None:
@@ -289,6 +290,6 @@ def test_detect_folder_single_frame(monkeypatch, tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("rows", [[[0, 0, 1, 1, 0.9, 0]]])
 def test_filter_cpu(rows) -> None:
-    assert dobj._filter_detections(rows, 0.5)
+    assert dobj._filter_detections(rows, 0.5, [0])
 
 


### PR DESCRIPTION
## Summary
- support `--classes` in `src.detect_objects` to choose detection classes
- update `detect_image` and detection helper to accept class ids
- document new option in README
- test CLI defaults and detection filtering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68836234d2b4832f82b3a6a8f3e0ba0a