### PR TITLE
Implement class filtering and improved ROI labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,9 @@ The Pillow and NumPy packages used by ``frame_enhancer.py`` come from
 ## Object Detection CLI
 
 Run YOLOX object detection on extracted frames. A CUDA-enabled GPU and YOLOX
-``v0.3`` or newer are required. The ``--classes`` option controls which object
-categories to keep (default: ``0 32`` where ``32`` is ``sports ball``).
+``v0.3`` or newer are required. The ``--classes`` option takes one or more
+numeric class IDs. Only detections for these IDs are written to
+``detections.json``. By default ``0 32`` keeps ``person`` and ``sports ball``.
 
 ```bash
 python -m src.detect_objects \
@@ -149,13 +150,14 @@ Overlay detection bounding boxes on extracted frames.
 python -m src.draw_roi \
     --frames-dir frames/ \
     --detections-json detections.json \
-    --output-dir frames_roi/
+    --output-dir frames_roi/ \
+    --label
 ```
 
 The command reads detection results from ``detections.json`` and writes
-annotated images to ``frames_roi`` using red rectangles by default. The
-bounding box coordinates are expected to match the original frame pixels,
-so no scaling is applied when drawing.
+annotated images to ``frames_roi``. Using ``--label`` draws the COCO class name
+and confidence score above each box. The bounding box coordinates are expected
+to match the original frame pixels, so no scaling is applied when drawing.
 
 ## Detection Validation CLI
 

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -103,7 +103,7 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
         nargs="+",
         type=int,
         default=list(CLASS_MAP.values()),
-        help="Class IDs to detect",
+        help="Numeric class IDs to keep (default: person and sports ball)",
     )
     return parser.parse_args(argv)
 
@@ -199,7 +199,8 @@ def detect_folder(
 ) -> None:
     """Run detection over ``frames_dir`` and write results.
 
-    Only detections with ``class_ids`` are kept.
+    Only detections with IDs in ``class_ids`` are written. If ``class_ids`` is
+    ``None``, ``[0, 32]`` (``person`` and ``sports ball``) are used.
 
     Args:
         frames_dir: Directory containing frame images.
@@ -209,7 +210,7 @@ def detect_folder(
     """
     model = _load_model(model_name)
     if class_ids is None:
-        class_ids = [CLASS_MAP["person"]]
+        class_ids = list(CLASS_MAP.values())
     frames = sorted(
         [p for p in frames_dir.iterdir() if p.suffix.lower() in {".jpg", ".png"}]
     )
@@ -296,10 +297,6 @@ def main(argv: Iterable[str] | None = None) -> None:
         level=logging.INFO, format="%(asctime)s %(levelname)s: %(message)s"
     )
     try:
-        invalid = [c for c in args.classes if c not in CLASS_MAP.values()]
-        if invalid:
-            valid = ", ".join(str(v) for v in sorted(CLASS_MAP.values()))
-            raise SystemExit(f"Unknown class id {invalid[0]}. Available: {valid}")
         detect_folder(
             args.frames_dir,
             args.output_json,

--- a/src/draw_roi.py
+++ b/src/draw_roi.py
@@ -169,10 +169,88 @@ def _color_bgr(name: str) -> Tuple[int, int, int]:
     return colors.get(name.lower(), (0, 0, 255))
 
 
-CLASS_NAMES = {
-    0: "person",
-    32: "ball",
-}
+COCO_CLASS_NAMES = (
+    "person",
+    "bicycle",
+    "car",
+    "motorcycle",
+    "airplane",
+    "bus",
+    "train",
+    "truck",
+    "boat",
+    "traffic light",
+    "fire hydrant",
+    "stop sign",
+    "parking meter",
+    "bench",
+    "bird",
+    "cat",
+    "dog",
+    "horse",
+    "sheep",
+    "cow",
+    "elephant",
+    "bear",
+    "zebra",
+    "giraffe",
+    "backpack",
+    "umbrella",
+    "handbag",
+    "tie",
+    "suitcase",
+    "frisbee",
+    "skis",
+    "snowboard",
+    "sports ball",
+    "kite",
+    "baseball bat",
+    "baseball glove",
+    "skateboard",
+    "surfboard",
+    "tennis racket",
+    "bottle",
+    "wine glass",
+    "cup",
+    "fork",
+    "knife",
+    "spoon",
+    "bowl",
+    "banana",
+    "apple",
+    "sandwich",
+    "orange",
+    "broccoli",
+    "carrot",
+    "hot dog",
+    "pizza",
+    "donut",
+    "cake",
+    "chair",
+    "couch",
+    "potted plant",
+    "bed",
+    "dining table",
+    "toilet",
+    "tv",
+    "laptop",
+    "mouse",
+    "remote",
+    "keyboard",
+    "cell phone",
+    "microwave",
+    "oven",
+    "toaster",
+    "sink",
+    "refrigerator",
+    "book",
+    "clock",
+    "vase",
+    "scissors",
+    "teddy bear",
+    "hair drier",
+    "toothbrush",
+)
 
 
 CLASS_COLORS = {
@@ -240,10 +318,14 @@ def draw_rois(
                     class_id = det.get("class", -1)
                     score = det.get("score")
                     clr = _label_color(class_id)
-                    class_name = CLASS_NAMES.get(class_id, f"id{class_id}")
-                    text = class_name
-                    if score is not None:
-                        text += f" {int(score * 100)}%"
+                    if 0 <= class_id < len(COCO_CLASS_NAMES):
+                        class_name = COCO_CLASS_NAMES[class_id]
+                    else:
+                        class_name = f"id{class_id}"
+                    if score is None:
+                        text = class_name
+                    else:
+                        text = f"{class_name}:{score * 100:.1f}%"
                     (tw, th), bl = cv2.getTextSize(
                         text, cv2.FONT_HERSHEY_SIMPLEX, 0.7, 2
                     )

--- a/tests/test_draw_roi.py
+++ b/tests/test_draw_roi.py
@@ -137,5 +137,4 @@ def test_draw_rois_label_coloring(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     expected = dr._label_color(0)
     assert dummy.rectangles[0][2] == expected
     assert dummy.texts
-    assert "person" in dummy.texts[0][0]
-    assert "90%" in dummy.texts[0][0]
+    assert "person:90.0%" in dummy.texts[0][0]


### PR DESCRIPTION
## Summary
- keep only selected class IDs when saving detections
- accept numeric class IDs on the CLI
- use COCO_CLASS_NAMES for ROI labels and display "class:score%"
- update README with examples
- adjust ROI tests for the new label format

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688371661010832f986e044c052681c7