### PR TITLE
Fix detection class filtering

### DIFF
--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -208,8 +208,8 @@ def detect_folder(
         img_size: Target input size for the model.
     """
     model = _load_model(model_name)
-    # Always keep only person and sports ball detections.
-    class_ids = list(CLASS_MAP.values())
+    if class_ids is None:
+        class_ids = list(CLASS_MAP.values())
     frames = sorted(
         [p for p in frames_dir.iterdir() if p.suffix.lower() in {".jpg", ".png"}]
     )

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -63,6 +63,21 @@ def test_parse_args_defaults() -> None:
     assert args.classes == [0, 32]
 
 
+def test_parse_args_custom_classes() -> None:
+    args = dobj.parse_args(
+        [
+            "--frames-dir",
+            "frames",
+            "--output-json",
+            "out.json",
+            "--classes",
+            "1",
+            "2",
+        ]
+    )
+    assert args.classes == [1, 2]
+
+
 def test_load_model_translates_hyphen(monkeypatch) -> None:
     recorded = {}
 
@@ -283,7 +298,7 @@ def test_detect_folder_single_frame(monkeypatch, tmp_path: Path) -> None:
 
     assert len(data) == 1
     assert data[0]["detections"]
-
+    
     sys.modules.pop("yolox.utils", None)
     sys.modules.pop("yolox", None)
 
@@ -291,5 +306,63 @@ def test_detect_folder_single_frame(monkeypatch, tmp_path: Path) -> None:
 @pytest.mark.parametrize("rows", [[[0, 0, 1, 1, 0.9, 0]]])
 def test_filter_cpu(rows) -> None:
     assert dobj._filter_detections(rows, 0.5, [0])
+
+
+def test_detect_folder_respects_classes(monkeypatch, tmp_path: Path) -> None:
+    frames = tmp_path / "frames"
+    frames.mkdir()
+    (frames / "img.jpg").write_bytes(b"\x00")
+
+    class FakeDet(list):
+        dtype = "float32"
+
+        def tolist(self):
+            return [list(self)]
+
+        def cpu(self):
+            return self
+
+    class FakeModel:
+        head = types.SimpleNamespace(decode_outputs=lambda o, dtype: o)
+
+        def __call__(self, tensor):
+            return [[FakeDet([0.0, 0.0, 1.0, 1.0, 0.9, 42])]]
+
+    monkeypatch.setattr(dobj, "_load_model", lambda *a, **k: FakeModel())
+
+    module = types.ModuleType("yolox")
+    utils_mod = types.ModuleType("utils")
+    utils_mod.postprocess = (
+        lambda outputs, num_classes, conf_thre, nms_thre, class_agnostic=False: [
+            FakeDet([0.0, 0.0, 1.0, 1.0, 0.9, 42])
+        ]
+    )
+    module.utils = utils_mod
+    sys.modules["yolox"] = module
+    sys.modules["yolox.utils"] = utils_mod
+
+    class DummyTensor:
+        def unsqueeze(self, dim):
+            return self
+
+        def cuda(self):
+            return self
+
+    monkeypatch.setattr(
+        dobj,
+        "_preprocess_image",
+        lambda p, s: (DummyTensor(), 1.0, 0, 0, 10, 10),
+    )
+
+    out_json = tmp_path / "det.json"
+    dobj.detect_folder(frames, out_json, "yolox-s", 640, class_ids=[42])
+
+    with out_json.open() as fh:
+        data = json.load(fh)
+
+    assert data[0]["detections"][0]["class"] == 42
+
+    sys.modules.pop("yolox.utils", None)
+    sys.modules.pop("yolox", None)
 
 


### PR DESCRIPTION
## Summary
- allow `detect_folder` to use provided class IDs
- add tests ensuring CLI class arguments are parsed and respected

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68837609776c832f8253aa340fd86f7b