### PR TITLE
Improve detection class handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ The Pillow and NumPy packages used by ``frame_enhancer.py`` come from
 
 Run YOLOX object detection on extracted frames. A CUDA-enabled GPU and YOLOX
 ``v0.3`` or newer are required. The ``--classes`` option takes one or more
-numeric class IDs. Only detections for these IDs are written to
-``detections.json``. By default ``0 32`` keeps ``person`` and ``sports ball``.
+numeric class IDs. If omitted, detections for all classes are kept. For
+example, ``--classes 0 32`` keeps only ``person`` and ``sports ball``.
 
 ```bash
 python -m src.detect_objects \

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -35,6 +35,9 @@ LOGGER = logging.getLogger(__name__)
 
 YOLOX_MODELS = {"yolox-s", "yolox-m", "yolox-l", "yolox-x"}
 
+# Number of classes in the default COCO-trained YOLOX models.
+YOLOX_NUM_CLASSES = 80
+
 # Mapping of human-readable class names to COCO class IDs. Adjust if using a
 # different dataset.
 CLASS_MAP = {
@@ -102,8 +105,8 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
         "--classes",
         nargs="+",
         type=int,
-        default=list(CLASS_MAP.values()),
-        help="Numeric class IDs to keep (default: person and sports ball)",
+        default=None,
+        help="Numeric class IDs to keep. Defaults to all classes",
     )
     return parser.parse_args(argv)
 
@@ -199,7 +202,8 @@ def detect_folder(
 ) -> None:
     """Run detection over ``frames_dir`` and write results.
 
-    Only detections for ``person`` or ``sports ball`` are written.
+    If ``class_ids`` is not provided, detections for all YOLOX classes are
+    returned. Otherwise only detections for the specified classes are kept.
 
     Args:
         frames_dir: Directory containing frame images.
@@ -209,7 +213,7 @@ def detect_folder(
     """
     model = _load_model(model_name)
     if class_ids is None:
-        class_ids = list(CLASS_MAP.values())
+        class_ids = list(range(YOLOX_NUM_CLASSES))
     frames = sorted(
         [p for p in frames_dir.iterdir() if p.suffix.lower() in {".jpg", ".png"}]
     )

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -60,7 +60,7 @@ def test_parse_args_defaults() -> None:
     assert isinstance(args, argparse.Namespace)
     assert args.model == "yolox-s"
     assert args.img_size == 640
-    assert args.classes == [0, 32]
+    assert args.classes is None
 
 
 def test_parse_args_custom_classes() -> None:


### PR DESCRIPTION
## Summary
- allow selecting all classes when running detection
- update README with new `--classes` behavior
- adjust tests for new default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688379a89d70832fa46020802ca041cb