### PR TITLE
Switch frame extractor output to PNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ python src/frame_extractor.py -i <video.mp4> -o /path/to/output -f 30
 ```
 
 - `-i`, `--input`: Path to input video.
-- `-o`, `--output`: Output directory for JPEG frames.
+- `-o`, `--output`: Output directory for PNG frames.
 - `-f`, `--fps`: Frames per second to extract (default: 30).
 - `-v`, `--verbose`: Increase logging detail.
 
@@ -125,13 +125,13 @@ Example ``detections.json`` output:
 ```json
 [
   {
-    "frame": "frame_000001.jpg",
+    "frame": "frame_000001.png",
     "detections": [
       {"bbox": [15, 30, 210, 330], "score": 0.91, "class": 0}
     ]
   },
   {
-    "frame": "frame_000002.jpg",
+    "frame": "frame_000002.png",
     "detections": []
   }
 ]

--- a/src/frame_extractor.py
+++ b/src/frame_extractor.py
@@ -43,7 +43,7 @@ def build_ffmpeg_command(input_video: str, output_dir: str, fps: int) -> List[st
     Returns:
         List of command tokens.
     """
-    output_pattern = os.path.join(output_dir, "frame_%06d.jpg")
+    output_pattern = os.path.join(output_dir, "frame_%06d.png")
     return [
         "ffmpeg",
         "-hide_banner",
@@ -135,7 +135,7 @@ def extract_frames(input_video: Path, output_dir: Path, fps: int) -> None:
         str(input_video),
         "-vf",
         f"fps={fps}",
-        str(output_dir / "frame_%06d.jpg"),
+        str(output_dir / "frame_%06d.png"),
         "-loglevel",
         "error",
         "-progress",

--- a/tests/test_frame_extractor.py
+++ b/tests/test_frame_extractor.py
@@ -94,5 +94,5 @@ def test_extract_frames(tmp_path: Path) -> None:
 
     frame_extractor.extract_frames(video, output_dir, fps=10)
 
-    extracted = list(output_dir.glob("*.jpg"))
+    extracted = list(output_dir.glob("*.png"))
     assert extracted, "No frames were extracted"

--- a/tests/test_validate_detections.py
+++ b/tests/test_validate_detections.py
@@ -36,11 +36,11 @@ class DummyImage:
 def test_sanity_check_counts(tmp_path: Path, monkeypatch) -> None:
     frames = tmp_path / "frames"
     frames.mkdir()
-    (frames / "f1.jpg").write_bytes(b"\x00")
+    (frames / "f1.png").write_bytes(b"\x00")
 
     det_json = tmp_path / "det.json"
     det_json.write_text(
-        "[{'frame': 'f1.jpg', 'detections': [{'bbox': [0,0,5,5], 'score': 0.2},"
+        "[{'frame': 'f1.png', 'detections': [{'bbox': [0,0,5,5], 'score': 0.2},"
         " {'bbox': [-1,0,2,2], 'score': 0.9}]}]".replace("'", '"')
     )
 


### PR DESCRIPTION
## Summary
- save frames from `frame_extractor.py` as PNG instead of JPG
- document PNG output in README
- update frame extraction and validation tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c667a9a8832f94ed06f697227515