### PR TITLE
Switch draw_roi output to PNG

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ python -m src.draw_roi \
 ```
 
 The command reads detection results from ``detections.json`` and writes
-annotated images to ``frames_roi``. Using ``--label`` draws the COCO class name
+annotated PNG images to ``frames_roi``. Using ``--label`` draws the COCO class name
 and confidence score above each box. The bounding box coordinates are expected
 to match the original frame pixels, so no scaling is applied when drawing.
 

--- a/src/draw_roi.py
+++ b/src/draw_roi.py
@@ -44,7 +44,7 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
         "--output-dir",
         type=Path,
         required=True,
-        help="Where annotated frames will be written",
+        help="Where annotated PNG frames will be written",
     )
     parser.add_argument(
         "--img-size",
@@ -273,12 +273,12 @@ def draw_rois(
     color: str = "red",
     label: bool = False,
 ) -> None:
-    """Overlay detection ROIs on frames and save to ``output_dir``.
+    """Overlay detection ROIs on frames and save to ``output_dir`` as PNG.
 
     Args:
         frames_dir: Directory of frame images.
         detections_json: JSON file with detection results.
-        output_dir: Destination for annotated images.
+        output_dir: Destination for annotated PNG images.
         img_size: Unused. Present for backwards compatibility.
         color: Outline color for rectangles.
         label: If ``True``, color boxes by class and draw labels with score.
@@ -349,7 +349,8 @@ def draw_rois(
                     "Discarded invalid box %s from %s", [x1, y1, x2, y2], frame_name
                 )
 
-        out_path = output_dir / frame_name
+        out_name = Path(frame_name).with_suffix(".png").name
+        out_path = output_dir / out_name
         cv2.imwrite(str(out_path), img)
         LOGGER.debug("Wrote %s", out_path)
 

--- a/tests/test_draw_roi.py
+++ b/tests/test_draw_roi.py
@@ -88,15 +88,15 @@ def test_draw_rois_writes_files(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
 
     frames = tmp_path / "frames"
     frames.mkdir()
-    (frames / "img.jpg").write_bytes(b"\x00")
+    (frames / "img.png").write_bytes(b"\x00")
 
     det_json = tmp_path / "det.json"
-    det_json.write_text('[{"frame": "img.jpg", "detections": [{"bbox": [1, 1, 5, 5]}]}]')
+    det_json.write_text('[{"frame": "img.png", "detections": [{"bbox": [1, 1, 5, 5]}]}]')
 
     out_dir = tmp_path / "out"
     dr.draw_rois(frames, det_json, out_dir, 640, color="blue")
 
-    out_img = out_dir / "img.jpg"
+    out_img = out_dir / "img.png"
     assert out_img.exists()
     assert dummy_cv2.rectangles
 
@@ -106,15 +106,15 @@ def test_draw_rois_sanitizes_bbox(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
 
     frames = tmp_path / "frames"
     frames.mkdir()
-    (frames / "img.jpg").write_bytes(b"\x00")
+    (frames / "img.png").write_bytes(b"\x00")
 
     det_json = tmp_path / "det.json"
-    det_json.write_text('[{"frame": "img.jpg", "detections": [{"bbox": [5, 5, 1, 1]}]}]')
+    det_json.write_text('[{"frame": "img.png", "detections": [{"bbox": [5, 5, 1, 1]}]}]')
 
     out_dir = tmp_path / "out"
     dr.draw_rois(frames, det_json, out_dir, 640)
 
-    assert (out_dir / "img.jpg").exists()
+    assert (out_dir / "img.png").exists()
 
 
 def test_draw_rois_label_coloring(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -123,11 +123,11 @@ def test_draw_rois_label_coloring(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
 
     frames = tmp_path / "frames"
     frames.mkdir()
-    (frames / "img.jpg").write_bytes(b"\x00")
+    (frames / "img.png").write_bytes(b"\x00")
 
     det_json = tmp_path / "det.json"
     det_json.write_text(
-        '[{"frame": "img.jpg", "detections": [{"bbox": [1, 1, 5, 5], "class": 0, "score": 0.9}]}]'
+        '[{"frame": "img.png", "detections": [{"bbox": [1, 1, 5, 5], "class": 0, "score": 0.9}]}]'
     )
 
     out_dir = tmp_path / "out"


### PR DESCRIPTION
## Summary
- update `draw_roi` CLI to always save PNG files
- adapt ROI drawing tests for PNG outputs
- document PNG output in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883caf39010832f91291a2d39a91a9b