### PR TITLE
Fix default subcommand for detect_objects CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,14 +91,29 @@ numeric class IDs. If omitted, detections for all classes are kept. For
 example, ``--classes 0 32`` keeps only ``person`` and ``sports ball``.
 
 ```bash
+# 1) Явно з detect
+python -m src.detect_objects detect \
+  --frames-dir    ./frames \
+  --output-json   detections.json \
+  --model         yolox-x \
+  --img-size      1280 \
+  --conf-thres    0.1 \
+  --nms-thres     0.1
+
+# 2) Без сабкоманди (виконання detect за замовчуванням)
 python -m src.detect_objects \
-    --frames-dir frames/ \
-    --output-json detections.json \
-    --model yolox-s \
-    --img-size 640 \
-    --conf-thres 0.30 \
-    --nms-thres 0.45 \
-    --classes 0 32
+  --frames-dir    ./frames \
+  --output-json   detections.json \
+  --model         yolox-x \
+  --img-size      1280 \
+  --conf-thres    0.1 \
+  --nms-thres     0.1
+
+# 3) Трекінг
+python -m src.detect_objects track \
+  --detections-json detections.json \
+  --output-json     tracks.json \
+  --min-score       0.3
 ```
 
 To use the GPU-enabled Docker image, build it with ``Dockerfile.detect``:

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -70,7 +70,7 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments for detection and tracking."""
 
     parser = argparse.ArgumentParser(description=__doc__)
-    sub = parser.add_subparsers(dest="command")
+    sub = parser.add_subparsers(dest="command", required=False)
 
     # Detection subcommand (default)
     det = sub.add_parser("detect", help="Run YOLOX detection")
@@ -88,9 +88,13 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     tr.add_argument("--output-json", type=Path, required=True)
     tr.add_argument("--min-score", type=float, default=0.3)
 
-    if argv and argv[0] in {"detect", "track"}:
-        return parser.parse_args(argv)
-    return parser.parse_args(["detect"] + ([] if argv is None else list(argv)))
+    # Parse provided arguments or ``sys.argv`` when ``argv`` is ``None``.
+    args = parser.parse_args(argv)
+
+    # Default to ``detect`` when no subcommand is supplied.
+    if args.command is None:
+        args.command = "detect"
+    return args
 
 
 def _load_model(model_name: str):


### PR DESCRIPTION
## Summary
- ensure parse_args respects CLI arguments when called via `python -m src.detect_objects`
- show explicit examples for using detect and track in README

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688746b4b818832fba22608d89fb79ac