### PR TITLE
vendor ByteTrack as submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.pyc
+externals/ByteTrack/build/
+externals/ByteTrack/*.so

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "externals/ByteTrack"]
+path = externals/ByteTrack
+url = https://github.com/ifzhang/ByteTrack.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,13 @@ FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        python3 python3-pip ffmpeg && \
+        python3 python3-pip ffmpeg \
+        build-essential \
+        cmake \
+        ninja-build \
+        git \
+        libopencv-dev \
+        python3-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt
@@ -10,5 +16,6 @@ RUN pip3 install --no-cache-dir -r /tmp/requirements.txt
 
 WORKDIR /app
 COPY . /app
+RUN bash build_externals.sh
 
 ENTRYPOINT ["bash"]

--- a/Dockerfile.detect
+++ b/Dockerfile.detect
@@ -4,8 +4,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ffmpeg \
         cmake \
+        ninja-build \
         git \
-        build-essential && \
+        build-essential \
+        libopencv-dev \
+        python3-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt
@@ -15,5 +18,6 @@ RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && \
 
 WORKDIR /app
 COPY . /app
+RUN bash build_externals.sh
 
 ENTRYPOINT ["python", "-m", "src.detect_objects"]

--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -4,8 +4,11 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ffmpeg \
         cmake \
+        ninja-build \
         git \
-        build-essential && \
+        build-essential \
+        libopencv-dev \
+        python3-dev && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt
@@ -14,5 +17,6 @@ RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && \
 
 WORKDIR /app
 COPY . /app
+RUN bash build_externals.sh
 
 ENTRYPOINT ["python", "-m", "src.detect_image"]

--- a/README.md
+++ b/README.md
@@ -23,11 +23,26 @@ The script requires FFmpeg to be installed and available on the system path.
 
 ## Setup
 
-Install the required Python packages and run tests:
+Install the system dependencies and Python packages, then fetch the
+``ByteTrack`` submodule and build its native extensions.
 
 ```bash
-python -m pip install -U -r requirements.txt
+sudo apt update
+sudo apt install -y build-essential cmake ninja-build libopencv-dev python3-dev
+git submodule update --init --recursive
+python -m pip install --upgrade pip setuptools wheel
+python -m pip install -r requirements.txt
+bash build_externals.sh
 make test
+```
+
+### External Dependencies
+
+Build the vendored ByteTrack tracker:
+
+```bash
+git submodule update --init --recursive
+bash build_externals.sh
 ```
 
 Build the Docker image (requires NVIDIA GPU drivers):
@@ -160,8 +175,9 @@ GitHub repository to avoid issues with the PyPI release.
 ## Object Tracking CLI
 
 After running detection you can generate consistent tracks for each
-``person`` and ``ball`` class using ByteTrack. Only detections with score
-above ``--min-score`` are considered.
+``person`` and ``ball`` class using ByteTrack. The tracker is vendored in
+``externals/ByteTrack`` and must be built via ``build_externals.sh``.
+Only detections with score above ``--min-score`` are considered.
 
 ```bash
 python -m src.detect_objects track \

--- a/build_externals.sh
+++ b/build_externals.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Build C++ extensions for vendored dependencies such as ByteTrack.
+
+pushd "$(dirname "$0")/externals/ByteTrack" >/dev/null
+
+pip install --user cython pybind11 packaging
+python setup.py build_ext --inplace
+
+popd >/dev/null
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ numpy>=1.26
 loguru>=0.7
 opencv-python-headless>=4.10
 tabulate>=0.9
-bytetrack>=0.3

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -25,8 +25,17 @@ from typing import Iterable, List, Tuple, Sequence, Dict
 
 from loguru import logger
 
+import os
+import sys
+
+BYTETRACK_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "../externals/ByteTrack")
+)
+if BYTETRACK_PATH not in sys.path:
+    sys.path.insert(0, BYTETRACK_PATH)
+
 try:  # ByteTrack is optional for unit tests
-    from bytetrack import BYTETracker
+    from tracker.byte_tracker import BYTETracker
 except Exception:  # pragma: no cover - optional dependency
     BYTETracker = None  # type: ignore
 
@@ -296,7 +305,7 @@ def track_detections(
 
     if BYTETracker is None:
         raise ImportError(
-            "BYTETracker is required. Install with 'pip install bytetrack'"
+            "BYTETracker is required. Run 'bash build_externals.sh' to compile it"
         )
 
     with detections_json.open() as fh:


### PR DESCRIPTION
## Summary
- vendor ByteTrack submodule
- add build_externals.sh helper
- update imports to use local tracker
- drop ByteTrack from requirements
- update docs and Dockerfiles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887489351b0832f85df33bf2d3f7b7a