### PR TITLE
Improve ByteTrack setup notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ sudo apt install -y build-essential cmake ninja-build libopencv-dev python3-dev
 git submodule update --init --recursive
 python -m pip install --upgrade pip setuptools wheel
 python -m pip install -r requirements.txt
+python -m pip install pytest
 bash build_externals.sh
 make test
 ```
@@ -57,6 +58,28 @@ Build the vendored ByteTrack tracker:
 git submodule update --init --recursive
 bash build_externals.sh
 ```
+
+If `build_externals.sh` exits with the message:
+
+```
+ByteTrack submodule not found.
+Run 'git submodule update --init --recursive' first.
+```
+
+the repository was cloned without the ByteTrack code. Re-fetch the submodule or clone it manually:
+
+```bash
+git submodule update --init --recursive
+# or, if the folder is empty
+rm -rf externals/ByteTrack
+git clone https://github.com/ifzhang/ByteTrack.git externals/ByteTrack
+```
+
+If the clone fails with a `CONNECT tunnel failed: 403` error, it
+is due to network restrictions. Re-run the command once internet
+access is restored or fetch the code via another method.
+
+Then run `bash build_externals.sh` again.
 
 Build the Docker image (requires NVIDIA GPU drivers):
 

--- a/build_externals.sh
+++ b/build_externals.sh
@@ -18,8 +18,13 @@ set -euo pipefail
 BYTE_DIR="$(dirname "$0")/externals/ByteTrack"
 
 if [ ! -f "$BYTE_DIR/setup.py" ]; then
-    echo "ByteTrack submodule not found.\n" \
-         "Run 'git submodule update --init --recursive' first." >&2
+    echo "ByteTrack submodule not found." >&2
+    echo "Run 'git submodule update --init --recursive' first." >&2
+    echo "If the directory is empty you can clone it manually:" >&2
+    echo "  rm -rf externals/ByteTrack" >&2
+    echo "  git clone https://github.com/ifzhang/ByteTrack.git externals/ByteTrack" >&2
+    echo "If cloning fails with 'CONNECT tunnel failed: 403', try again when" >&2
+    echo "network access is available." >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- expand setup instructions to install `pytest`
- document troubleshooting steps for missing ByteTrack submodule
- show manual clone commands in `build_externals.sh`
- mention 403 tunnel errors when the clone fails due to network restrictions

## Testing
- `pytest -q`
- `pip install flake8` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68875356bb1c832fa7960fa910587c05