### PR TITLE
Fix pytest collection

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -ra


### PR DESCRIPTION
## Summary
- restrict pytest to run tests in `tests` directory using pytest.ini

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68875a344bf4832f8625901fca8fdbf2