### PR TITLE
Fix Docker timezone configuration for noninteractive builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,20 @@
 FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
 
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        python3 python3-pip ffmpeg \
+        python3 python3-pip ffmpeg tzdata \
         build-essential \
         cmake \
         ninja-build \
         git \
         libopencv-dev \
         python3-dev && \
+    ln -sf /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    dpkg-reconfigure --frontend noninteractive tzdata && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt


### PR DESCRIPTION
## Summary
- configure tzdata in Dockerfile to avoid interactive prompts
- set timezone to UTC and reconfigure in container

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688763c31c6c832f9085c8d83e071954