### PR TITLE
Fix Python path in build script

### DIFF
--- a/build_externals.sh
+++ b/build_externals.sh
@@ -29,7 +29,8 @@ if [ ! -f "$BYTE_DIR/setup.py" ]; then
 fi
 
 pushd "$BYTE_DIR" >/dev/null
-pip install --user cython pybind11 packaging
-python setup.py build_ext --inplace
+# Use Python 3 explicitly in Docker since `python` may not be installed.
+python3 -m pip install --user cython pybind11 packaging
+python3 setup.py build_ext --inplace
 popd >/dev/null
 


### PR DESCRIPTION
## Summary
- ensure build_externals.sh uses `python3` explicitly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68876a11cd78832f96c23ed0d404a7d5