### PR TITLE
Fix ByteTrack sys.path entry

### DIFF
--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -28,9 +28,9 @@ from loguru import logger
 import os
 import sys
 
-# Location of the vendored ByteTrack package.
+# Add the ByteTrack repo root so that "bytetrack" package is importable
 BT_ROOT = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), "../externals/ByteTrack/bytetrack")
+    os.path.join(os.path.dirname(__file__), "../externals/ByteTrack")
 )
 if BT_ROOT not in sys.path:
     sys.path.insert(0, BT_ROOT)


### PR DESCRIPTION
## Summary
- correct path insertion for ByteTrack so that package imports succeed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688776811808832fa3bed2fc747c1330