### PR TITLE
Fix BYTETracker import

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ numpy>=1.26
 loguru>=0.7
 opencv-python-headless>=4.10
 tabulate>=0.9
+scipy>=1.11        # needed by tracker.byte_tracker fallback

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -28,7 +28,7 @@ from loguru import logger
 import os
 import sys
 
-# Add the ByteTrack repo root so that `bytetrack` package is importable
+# Add the ByteTrack repo root so that ByteTrack’s Python packages are importable
 BT_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "../externals/ByteTrack")
 )
@@ -36,8 +36,10 @@ if BT_ROOT not in sys.path:
     sys.path.insert(0, BT_ROOT)
 
 try:  # ByteTrack is optional for unit tests
-    from bytetrack.tracker.byte_tracker import BYTETracker
-except Exception:  # pragma: no cover - optional dependency
+    # ByteTrack stores the tracker code in tracker/byte_tracker.py
+    from tracker.byte_tracker import BYTETracker
+except Exception as exc:  # pragma: no cover - optional dependency
+    logger.error("Could not import BYTETracker: {}", exc)
     BYTETracker = None  # type: ignore
 
 from PIL import Image
@@ -306,7 +308,9 @@ def track_detections(
 
     if BYTETracker is None:
         raise ImportError(
-            "BYTETracker is required. Run 'bash build_externals.sh' to compile it"
+            "BYTETracker import failed. Make sure you have run:\n"
+            "  pip install -r requirements.txt   # adds scipy\n"
+            "  bash build_externals.sh           # compiles yolox C-extension\n"
         )
 
     with detections_json.open() as fh:

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -52,6 +52,8 @@ loguru_mod.logger = types.SimpleNamespace(
     error=lambda *a, **k: None,
 )
 sys.modules.setdefault("loguru", loguru_mod)
+sys.modules.setdefault("scipy", types.ModuleType("scipy"))
+sys.modules.setdefault("scipy.optimize", types.ModuleType("scipy.optimize")).linear_sum_assignment = lambda *a, **k: ([], [])
 
 import src.detect_objects as dobj
 


### PR DESCRIPTION
## Summary
- add SciPy dependency since tracker.byte_tracker falls back to it
- import BYTETracker from correct module
- log import failure details
- clarify error message if tracker missing
- mock scipy in tests to keep CI clean

## Testing
- `pytest -q`
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement torch>=2.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_688787570914832f8057ea99d6748c48