### PR TITLE
Fix BYTETracker import path

### DIFF
--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -36,7 +36,9 @@ if BT_ROOT not in sys.path:
     sys.path.insert(0, BT_ROOT)
 
 try:  # ByteTrack is optional for unit tests
-    # ByteTrack stores the tracker code in tracker/byte_tracker.py
+    # 1) import the ``bytetrack`` package so it appends the repo root to ``sys.path``
+    import bytetrack  # noqa: F401
+    # 2) now we can load ``BYTETracker`` from ``tracker.byte_tracker``
     from tracker.byte_tracker import BYTETracker
 except Exception as exc:  # pragma: no cover - optional dependency
     logger.error("Could not import BYTETracker: {}", exc)

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -54,6 +54,14 @@ loguru_mod.logger = types.SimpleNamespace(
 sys.modules.setdefault("loguru", loguru_mod)
 sys.modules.setdefault("scipy", types.ModuleType("scipy"))
 sys.modules.setdefault("scipy.optimize", types.ModuleType("scipy.optimize")).linear_sum_assignment = lambda *a, **k: ([], [])
+# dummy bytetrack + tracker.byte_tracker
+bt_mod = types.ModuleType("bytetrack")
+sys.modules["bytetrack"] = bt_mod
+# expose root-level tracker
+tracker_mod = types.ModuleType("tracker")
+sys.modules["tracker"] = tracker_mod
+tracker_mod.byte_tracker = types.ModuleType("tracker.byte_tracker")
+setattr(tracker_mod.byte_tracker, "BYTETracker", object)
 
 import src.detect_objects as dobj
 


### PR DESCRIPTION
## Summary
- import `bytetrack` first so `tracker.byte_tracker` becomes available
- adjust test dummy modules accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688789d1c894832f892a718f9863ad80