### PR TITLE
Fix ByteTrack import

### DIFF
--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -54,14 +54,10 @@ loguru_mod.logger = types.SimpleNamespace(
 sys.modules.setdefault("loguru", loguru_mod)
 sys.modules.setdefault("scipy", types.ModuleType("scipy"))
 sys.modules.setdefault("scipy.optimize", types.ModuleType("scipy.optimize")).linear_sum_assignment = lambda *a, **k: ([], [])
-# dummy bytetrack + tracker.byte_tracker
-bt_mod = types.ModuleType("bytetrack")
-sys.modules["bytetrack"] = bt_mod
-# expose root-level tracker
-tracker_mod = types.ModuleType("tracker")
-sys.modules["tracker"] = tracker_mod
-tracker_mod.byte_tracker = types.ModuleType("tracker.byte_tracker")
-setattr(tracker_mod.byte_tracker, "BYTETracker", object)
+# dummy byte_tracker module for dynamic import
+bt_mod = types.ModuleType("byte_tracker")
+setattr(bt_mod, "BYTETracker", object)
+sys.modules["byte_tracker"] = bt_mod
 
 import src.detect_objects as dobj
 


### PR DESCRIPTION
## Summary
- dynamically load ByteTrack by path instead of package import
- adjust detect_objects tests for new module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68878f3691d4832fa734c32f9ae1915c