### PR TITLE
Fix BYTETracker import path

### DIFF
--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -29,16 +29,16 @@ import importlib.util
 import os
 import sys
 
-# Locate ``tracker/byte_tracker.py`` in the bundled ByteTrack repository and
-# import ``BYTETracker`` directly from the file. The ByteTrack repo does not
-# provide a standard Python package, so importing by path avoids package hacks.
+# Locate the vendored ByteTrack repository and import ``BYTETracker`` from the
+# YOLOX-style package layout. The repository lives in ``externals/ByteTrack``
+# and exposes ``yolox.tracker.byte_tracker``.
 BT_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "../externals/ByteTrack")
 )
 if BT_ROOT not in sys.path:
     sys.path.insert(0, BT_ROOT)
 try:
-    from bytetrack.tracker.byte_tracker import BYTETracker
+    from yolox.tracker.byte_tracker import BYTETracker
 except Exception as exc:  # pragma: no cover - optional dependency
     logger.error("Could not import BYTETracker: {}", exc)
     BYTETracker = None

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -54,10 +54,12 @@ loguru_mod.logger = types.SimpleNamespace(
 sys.modules.setdefault("loguru", loguru_mod)
 sys.modules.setdefault("scipy", types.ModuleType("scipy"))
 sys.modules.setdefault("scipy.optimize", types.ModuleType("scipy.optimize")).linear_sum_assignment = lambda *a, **k: ([], [])
-# dummy byte_tracker module for dynamic import
-bt_mod = types.ModuleType("byte_tracker")
+# dummy ByteTrack module for dynamic import
+bt_mod = types.ModuleType("yolox.tracker.byte_tracker")
 setattr(bt_mod, "BYTETracker", object)
-sys.modules["byte_tracker"] = bt_mod
+sys.modules.setdefault("yolox", types.ModuleType("yolox"))
+sys.modules.setdefault("yolox.tracker", types.ModuleType("yolox.tracker"))
+sys.modules["yolox.tracker.byte_tracker"] = bt_mod
 
 import src.detect_objects as dobj
 


### PR DESCRIPTION
## Summary
- use yolox.tracker.byte_tracker when importing BYTETracker
- update test shim for new import path

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6887962eb38c832fb79aa2f0cdc5b47e