### PR TITLE
Fix ByteTrack import and add lap requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ loguru>=0.7
 opencv-python-headless>=4.10
 tabulate>=0.9
 scipy>=1.11        # needed by tracker.byte_tracker fallback
+# C-extension, needed for yolox.tracker.byte_tracker
+lap>=0.4

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -24,14 +24,12 @@ from pathlib import Path
 from typing import Iterable, List, Tuple, Sequence, Dict
 
 from loguru import logger
-
-import importlib.util
 import os
 import sys
 
-# Locate the vendored ByteTrack repository and import ``BYTETracker`` from the
-# YOLOX-style package layout. The repository lives in ``externals/ByteTrack``
-# and exposes ``yolox.tracker.byte_tracker``.
+# Add ByteTrack root to ``sys.path`` once and import ``BYTETracker`` normally.
+# The tracker module lives under ``yolox.tracker.byte_tracker`` in the bundled
+# repository at ``externals/ByteTrack``.
 BT_ROOT = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "../externals/ByteTrack")
 )


### PR DESCRIPTION
## Summary
- clean up ByteTrack import logic in `detect_objects.py`
- add `lap` dependency required by ByteTrack

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688798136cb0832faa6766888b4c8b75