### PR TITLE
Add cython_bbox dependency for BYTETracker

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ tabulate>=0.9
 scipy>=1.11        # needed by tracker.byte_tracker fallback
 # C-extension, needed for yolox.tracker.byte_tracker
 lap>=0.4
+cython_bbox>=0.1.3


### PR DESCRIPTION
## Summary
- include `cython_bbox` in requirements so BYTETracker works

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688798f115e8832fb5aa974c883edb6e