### PR TITLE
Fix track error for ball class

### DIFF
--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -69,6 +69,7 @@ YOLOX_MODELS = {"yolox-s", "yolox-m", "yolox-l", "yolox-x"}
 CLASS_MAP = {
     "person": 0,
     "sports ball": 32,
+    "ball": 32,  # alias for compatibility with other datasets
 }
 
 # Map CLI model names to torch.hub callable names.


### PR DESCRIPTION
## Summary
- add alias mapping for `ball` in tracker class map

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c239d13c832f98b8e45a1ee08877