### PR TITLE
Fix tracker signature handling

### DIFF
--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -159,8 +159,13 @@ def _update_tracker(tracker, tlwhs, scores, classes, frame_id):
         # different variants: outputs + img_info + img_size
         if len(params) == 3:
             return tracker.update(dets, img_info, img_size)
-        # len(params) == 2 -> without first arg
-        return tracker.update(img_info, img_size)
+        # len(params) == 2  ➜  дві можливості: (img_info, img_size)  або (dets, img_info)
+        try:
+            # (img_info, img_size)
+            return tracker.update(img_info, img_size)
+        except TypeError:
+            # (dets, img_info)
+            return tracker.update(dets, img_info)
 
     raise RuntimeError(f"Unknown BYTETracker.update signature: {params}")
 

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -293,6 +293,29 @@ def test_update_tracker_mot_three_params() -> None:
     assert tracker.args[0][0][:4] == [0, 0, 10, 20]
 
 
+def test_update_tracker_mot_two_params_dets_img_info() -> None:
+    class DummyTracker:
+        def __init__(self) -> None:
+            self.args = None
+
+        def update(self, dets, img_info):
+            self.args = (dets, img_info)
+            return ["ok"]
+
+    tracker = DummyTracker()
+    res = dobj._update_tracker(
+        tracker,
+        [[0, 0, 10, 20]],
+        [0.9],
+        ["person"],
+        1,
+    )
+
+    assert res == ["ok"]
+    assert tracker.args[1] == (20, 10, 1.0)
+    assert tracker.args[0][0][:4] == [0, 0, 10, 20]
+
+
 
 
 def test_detect_folder_uses_decode(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- handle 2-argument BYTETracker.update variants via try/except
- test fallback to `(dets, img_info)` call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c3c7b710832fa1b11cb48b2d787d