### PR TITLE
Fix tracker update call for ByteTrack

### DIFF
--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -127,7 +127,6 @@ def _update_tracker(tracker, tlwhs, scores, classes, frame_id):
     if params == ["tlwhs", "scores", "frame_id"]:
         return tracker.update(tlwhs, scores, frame_id)
 
-
     if params == ["dets", "frame_id"]:
         cls_arr = np.array([CLASS_MAP[c] for c in classes], dtype=np.float32)[:, None]
         dets = np.concatenate(
@@ -140,32 +139,30 @@ def _update_tracker(tracker, tlwhs, scores, classes, frame_id):
         )
         return tracker.update(dets, frame_id)
 
-    # --- version with 2-3 parameters MOT style ----------------------------
-    if "img_info" in params:
-        # ➊ Gather detections as expected by original ByteTrack:
-        #    [x1, y1, x2, y2, score, class_id]
+    # --- version with MOT style arguments --------------------------------
+    if {"img_info", "img_size"} & set(params):
         cls_arr = np.array([CLASS_MAP[c] for c in classes], dtype=np.float32)[:, None]
         dets = np.concatenate(
             [np.asarray(tlwhs, dtype=np.float32), np.asarray(scores, dtype=np.float32)[:, None], cls_arr],
             axis=1,
         )
 
-        # ➋ Roughly estimate frame size (or pass a tuple unused by tracker)
         im_w = max(b[0] + b[2] for b in tlwhs) if tlwhs else 1920
         im_h = max(b[1] + b[3] for b in tlwhs) if tlwhs else 1080
-        img_info = (im_h, im_w, 1.0)  # (h, w, scale)
+        img_info = (im_h, im_w, 1.0)
         img_size = (im_w, im_h)
 
-        # different variants: outputs + img_info + img_size
-        if len(params) == 3:
-            return tracker.update(dets, img_info, img_size)
-        # len(params) == 2  ➜  дві можливості: (img_info, img_size)  або (dets, img_info)
-        try:
-            # (img_info, img_size)
-            return tracker.update(img_info, img_size)
-        except TypeError:
-            # (dets, img_info)
-            return tracker.update(dets, img_info)
+        # Try common calling conventions for different ByteTrack versions.
+        for args in [
+            (dets, img_info, img_size),
+            (img_info, img_size),
+            (dets, img_info),
+            (dets, img_size),
+        ]:
+            try:
+                return tracker.update(*args)
+            except TypeError:
+                continue
 
     raise RuntimeError(f"Unknown BYTETracker.update signature: {params}")
 

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -316,6 +316,29 @@ def test_update_tracker_mot_two_params_dets_img_info() -> None:
     assert tracker.args[0][0][:4] == [0, 0, 10, 20]
 
 
+def test_update_tracker_mot_two_params_dets_img_size() -> None:
+    class DummyTracker:
+        def __init__(self) -> None:
+            self.args = None
+
+        def update(self, dets, img_size):
+            self.args = (dets, img_size)
+            return ["ok"]
+
+    tracker = DummyTracker()
+    res = dobj._update_tracker(
+        tracker,
+        [[0, 0, 10, 20]],
+        [0.9],
+        ["person"],
+        1,
+    )
+
+    assert res == ["ok"]
+    assert tracker.args[1] == (10, 20)
+    assert tracker.args[0][0][:4] == [0, 0, 10, 20]
+
+
 
 
 def test_detect_folder_uses_decode(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- fix `_update_tracker` to handle ByteTrack signatures requiring `img_size`
- support multiple calling conventions for tracker update
- add regression test for `(dets, img_size)` case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c50d0074832fbd12d2cf7c17838e