### PR TITLE
Support output_results BYTETracker signature

### DIFF
--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -141,6 +141,20 @@ def _update_tracker(tracker, tlwhs, scores, classes, frame_id):
         )
         return tracker.update(dets, frame_id)
 
+    if params == ["output_results", "img_info", "img_size"]:
+        cls_arr = np.array([CLASS_MAP[c] for c in classes], dtype=np.float32)[:, None]
+        dets = np.concatenate(
+            [np.asarray(tlwhs, dtype=np.float32), np.asarray(scores, dtype=np.float32)[:, None], cls_arr],
+            axis=1,
+        )
+
+        im_w = max(b[0] + b[2] for b in tlwhs) if tlwhs else 1920
+        im_h = max(b[1] + b[3] for b in tlwhs) if tlwhs else 1080
+        img_info = (im_h, im_w, 1.0)
+        img_size = (im_w, im_h)
+
+        return tracker.update(dets, img_info, img_size)
+
     # --- version with MOT style arguments --------------------------------
     if {"img_info", "img_size"} & set(params):
         cls_arr = np.array([CLASS_MAP[c] for c in classes], dtype=np.float32)[:, None]

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -293,6 +293,29 @@ def test_update_tracker_mot_three_params() -> None:
     assert tracker.args[0][0][:4] == [0, 0, 10, 20]
 
 
+def test_update_tracker_output_results_signature() -> None:
+    class DummyTracker:
+        def __init__(self) -> None:
+            self.args = None
+
+        def update(self, output_results, img_info, img_size):
+            self.args = (output_results, img_info, img_size)
+            return ["ok"]
+
+    tracker = DummyTracker()
+    res = dobj._update_tracker(
+        tracker,
+        [[0, 0, 10, 20]],
+        [0.9],
+        ["person"],
+        1,
+    )
+
+    assert res == ["ok"]
+    assert tracker.args[1:] == ((20, 10, 1.0), (10, 20))
+    assert tracker.args[0][0][:4] == [0, 0, 10, 20]
+
+
 def test_update_tracker_mot_two_params_dets_img_info() -> None:
     class DummyTracker:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- handle `output_results` argument pattern in `_update_tracker`
- test new signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887ca6fba90832f8349df55784b13e6