### PR TITLE
Handle Tensor input for BYTETracker

### DIFF
--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -153,6 +153,13 @@ def _update_tracker(tracker, tlwhs, scores, classes, frame_id):
         img_info = (im_h, im_w, 1.0)
         img_size = (im_w, im_h)
 
+        if torch is not None:
+            try:
+                dets_tensor = torch.as_tensor(dets, dtype=torch.float32)
+                return tracker.update(dets_tensor, img_info, img_size)
+            except Exception:
+                pass
+
         return tracker.update(dets, img_info, img_size)
 
     # --- version with MOT style arguments --------------------------------

--- a/tests/test_update_tracker_tensor.py
+++ b/tests/test_update_tracker_tensor.py
@@ -123,3 +123,38 @@ def test_update_tracker_tensor(monkeypatch) -> None:
 
     assert res == ["ok"]
     assert isinstance(tracker.args[0], DummyTensor)
+
+
+def test_update_tracker_output_results_tensor(monkeypatch) -> None:
+    class DummyTensor(list):
+        pass
+
+    class DummyTorch:
+        float32 = "float32"
+
+        def as_tensor(self, arr, dtype=None):
+            return DummyTensor(arr)
+
+    monkeypatch.setattr(dobj, "torch", DummyTorch())
+
+    class DummyTracker:
+        def __init__(self) -> None:
+            self.args = None
+
+        def update(self, output_results, img_info, img_size):
+            assert isinstance(output_results, DummyTensor)
+            self.args = (output_results, img_info, img_size)
+            return ["ok"]
+
+    tracker = DummyTracker()
+
+    res = dobj._update_tracker(
+        tracker,
+        [[0, 0, 10, 20]],
+        [0.9],
+        ["person"],
+        1,
+    )
+
+    assert res == ["ok"]
+    assert isinstance(tracker.args[0], DummyTensor)


### PR DESCRIPTION
## Summary
- convert detection array to `torch.Tensor` when BYTETracker expects `output_results`
- add regression test for `output_results` tensor handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887cd592174832f8cc084d311015146