### PR TITLE
Improve detection tracking with IoU matching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ lap>=0.4
 cython_bbox>=0.1.3
 # потрібен для сумісності з setuptools>=80
 packaging>=23.2
+shapely>=2.0


### PR DESCRIPTION
## Summary
- map ByteTrack results to detections by IoU instead of by index
- expose `_bbox_iou` helper using `shapely`
- depend on `shapely`
- test IoU-based matching

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'shapely')*

------
https://chatgpt.com/codex/tasks/task_e_6887d9ddb1cc832fa9ce1ce1f99c5cfe