### PR TITLE
Update tracker bounding box

### DIFF
--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -475,7 +475,9 @@ def track_detections(
         used_dets: set[int] = set()
 
         for obj in online:
-            tlbr = [obj.tlwh[0], obj.tlwh[1], obj.tlwh[0] + obj.tlwh[2], obj.tlwh[1] + obj.tlwh[3]]
+            # Access ByteTrack's internal bounding box representation directly for efficiency
+            x, y, w, h = obj._tlwh  # pylint: disable=protected-access
+            tlbr = [x, y, x + w, y + h]
             best_iou = 0.0
             best_idx: int | None = None
             for idx, det in frame_det_map.items():


### PR DESCRIPTION
## Summary
- tweak tracking to directly access `_tlwh`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'shapely')*

------
https://chatgpt.com/codex/tasks/task_e_6887de971198832f88c86ae252c7ff06