### PR TITLE
Fix STrack.tlwh property

### DIFF
--- a/externals/ByteTrack/yolox/tracker/byte_tracker.py
+++ b/externals/ByteTrack/yolox/tracker/byte_tracker.py
@@ -24,6 +24,11 @@ class STrack:
         self.score = 0.0
         self.track_id = -1
 
+    @property
+    def tlwh(self) -> np.ndarray:
+        """Return the track bounding box as ``(x, y, w, h)``."""
+        return self._tlwh
+
 
 class BYTETracker:
     """Dummy BYTETracker implementation."""


### PR DESCRIPTION
## Summary
- fix tracking stub by exposing `tlwh` property on `STrack`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'shapely')*
- `python -m src.detect_objects track --detections-json detections.json --output-json tracks.json --min-score 0.3` *(fails: No module named 'shapely')*

------
https://chatgpt.com/codex/tasks/task_e_6887df57d8d4832f9d5d4b3b2516a061