### PR TITLE
Configure logging with loguru

### DIFF
--- a/src/draw_tracks.py
+++ b/src/draw_tracks.py
@@ -13,6 +13,12 @@
 
 from __future__ import annotations
 
+import sys
+from loguru import logger
+
+logger.remove()
+logger.add(sys.stderr, level="INFO", format="{time:HH:mm:ss} | {level} | {message}")
+
 import hashlib
 import json
 import random
@@ -23,16 +29,6 @@ from typing import Dict, List, Tuple
 
 import click
 import cv2
-import sys
-from loguru import logger
-
-if hasattr(logger, "remove"):
-    logger.remove()
-    logger.add(
-        sys.stderr,
-        level="INFO",
-        format="{time:HH:mm:ss} | {level} | {message}",
-    )
 
 from .draw_roi import COCO_CLASS_NAMES, _label_color
 from .utils.draw_helpers import IMAGE_EXT, get_font, load_frames

--- a/tests/test_detect_image.py
+++ b/tests/test_detect_image.py
@@ -44,6 +44,8 @@ loguru_mod.logger = types.SimpleNamespace(
     debug=lambda *a, **k: None,
     warning=lambda *a, **k: None,
     error=lambda *a, **k: None,
+    remove=lambda *a, **k: None,
+    add=lambda *a, **k: None,
 )
 sys.modules.setdefault("loguru", loguru_mod)
 pil_mod = types.ModuleType("PIL")

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -50,6 +50,8 @@ loguru_mod.logger = types.SimpleNamespace(
     debug=lambda *a, **k: None,
     warning=lambda *a, **k: None,
     error=lambda *a, **k: None,
+    remove=lambda *a, **k: None,
+    add=lambda *a, **k: None,
 )
 sys.modules.setdefault("loguru", loguru_mod)
 sys.modules.setdefault("scipy", types.ModuleType("scipy"))

--- a/tests/test_update_tracker_tensor.py
+++ b/tests/test_update_tracker_tensor.py
@@ -25,6 +25,8 @@ loguru_mod.logger = types.SimpleNamespace(
     debug=lambda *a, **k: None,
     warning=lambda *a, **k: None,
     error=lambda *a, **k: None,
+    remove=lambda *a, **k: None,
+    add=lambda *a, **k: None,
 )
 sys.modules.setdefault("loguru", loguru_mod)
 


### PR DESCRIPTION
## Summary
- configure global logger in `draw_tracks`
- add dummy `remove` and `add` methods for loguru stubs in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888bee51a88832f8ad75f60723897fd