### PR TITLE
Fix loguru config initialization

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11,6 +11,13 @@
 # limitations under the License.
 """Package for video processing utilities."""
 
+import sys
+from loguru import logger
+
+# Configure a global loguru logger early so it works across modules.
+logger.remove()
+logger.add(sys.stderr, level="INFO", format="{time:HH:mm:ss} | {level} | {message}")
+
 __all__ = []
 
 

--- a/src/draw_tracks.py
+++ b/src/draw_tracks.py
@@ -14,10 +14,6 @@
 from __future__ import annotations
 
 from loguru import logger
-import sys
-
-logger.remove()
-logger.add(sys.stderr, level="INFO", format="{time:HH:mm:ss} | {level} | {message}")
 
 import hashlib
 import json
@@ -243,6 +239,8 @@ def cli(
     fps: float,
 ) -> None:
     """Command line interface for :func:`visualize_tracks`."""
+
+    logger.info("CLI started")
 
     visualize_tracks(
         frames_dir,


### PR DESCRIPTION
## Summary
- configure loguru globally in `src/__init__` so logging works from CLI
- remove logger setup from `draw_tracks`
- log when CLI starts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888c3570e5c832fb67601a86cf714e2