### PR TITLE
Enable BYTETracker for tracking

### DIFF
--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -235,8 +235,8 @@ def test_track_detections_assigns_ids(tmp_path: Path, monkeypatch) -> None:
     det_json.write_text(
         json.dumps(
             [
-                {"frame": "f1.png", "detections": [{"bbox": [0, 0, 2, 2], "score": 0.9, "class": 0}]},
-                {"frame": "f2.png", "detections": [{"bbox": [0, 0, 2, 2], "score": 0.9, "class": 0}]},
+                {"frame": 1, "class": "person", "bbox": [0, 0, 2, 2], "score": 0.9},
+                {"frame": 2, "class": "person", "bbox": [0, 0, 2, 2], "score": 0.9},
             ]
         )
     )
@@ -267,13 +267,8 @@ def test_track_detections_iou_matching(tmp_path: Path, monkeypatch) -> None:
     det_json.write_text(
         json.dumps(
             [
-                {
-                    "frame": "f1.png",
-                    "detections": [
-                        {"bbox": [0, 0, 2, 2], "score": 0.9, "class": 0},
-                        {"bbox": [10, 10, 12, 12], "score": 0.8, "class": 0},
-                    ],
-                }
+                {"frame": 1, "class": "person", "bbox": [0, 0, 2, 2], "score": 0.9},
+                {"frame": 1, "class": "person", "bbox": [10, 10, 12, 12], "score": 0.8},
             ]
         )
     )


### PR DESCRIPTION
## Summary
- rewrite `track_detections` to read flat detection lists
- instantiate BYTETracker with recommended parameters
- log frame detection/track counts
- adjust tracking tests for new detection format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a10367a1c832fb338db04bdc6fe44