### PR TITLE
Improve YOLOX experiment loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ The output ``tracks.json`` contains entries of the form:
 
 ```json
 [
-  {"frame": 1, "class": "person", "track_id": 5, "bbox": [x1, y1, x2, y2], "score": 0.93},
-  {"frame": 1, "class": "ball",   "track_id": 2, "bbox": [x1, y1, x2, y2], "score": 0.88}
+  {"frame": 1, "class": 0,  "track_id": 5, "bbox": [x1, y1, x2, y2], "score": 0.93},
+  {"frame": 1, "class": 32, "track_id": 2, "bbox": [x1, y1, x2, y2], "score": 0.88}
 ]
 ```
 

--- a/externals/ByteTrack/yolox/exp/__init__.py
+++ b/externals/ByteTrack/yolox/exp/__init__.py
@@ -1,0 +1,16 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Expose experiment loading utilities for YOLOX."""
+
+from .build import get_exp_by_name, get_exp_by_file, get_exp
+
+__all__ = ["get_exp_by_name", "get_exp_by_file", "get_exp"]

--- a/externals/ByteTrack/yolox/exp/build.py
+++ b/externals/ByteTrack/yolox/exp/build.py
@@ -1,0 +1,60 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Load YOLOX experiment definitions in a robust manner."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+from .default import *  # noqa: F401,F403
+
+
+def get_exp_by_name(exp_name: str):
+    """Load an :class:`Exp` given its name within ``yolox.exps.default``."""
+    import yolox
+
+    yolox_path = os.path.dirname(yolox.__file__)
+    exp_path = os.path.join(yolox_path, "exps", "default", exp_name + ".py")
+    return get_exp_by_file(exp_path)
+
+
+def get_exp_by_file(exp_file: str):
+    """Load an :class:`Exp` from a Python file path."""
+    exp_path = Path(exp_file).resolve()
+    if not exp_path.exists():
+        raise FileNotFoundError(f"Experiment file not found: {exp_file}")
+
+    module_name = exp_path.stem
+    spec = importlib.util.spec_from_file_location(module_name, str(exp_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load spec from {exp_file}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    if not hasattr(module, "Exp"):
+        raise ImportError(f"{exp_file} doesn't contain class named 'Exp'")
+
+    return module.Exp()
+
+
+def get_exp(exp_file: str | None = None, exp_name: str | None = None):
+    """Compatibility wrapper mimicking YOLOX's ``get_exp``."""
+    if exp_file:
+        return get_exp_by_file(exp_file)
+    if exp_name:
+        return get_exp_by_name(exp_name)
+    raise ValueError("Either exp_file or exp_name must be provided")

--- a/externals/ByteTrack/yolox/exp/default/__init__.py
+++ b/externals/ByteTrack/yolox/exp/default/__init__.py
@@ -1,0 +1,14 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Placeholder for YOLOX default experiments."""
+
+# This module can be expanded with actual Exp classes if needed.

--- a/tests/test_exp_build.py
+++ b/tests/test_exp_build.py
@@ -1,0 +1,40 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ``yolox.exp.build`` helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from yolox.exp import get_exp_by_file
+
+
+def test_get_exp_by_file_loads_custom_exp(tmp_path: Path) -> None:
+    exp_file = tmp_path / "custom_exp.py"
+    exp_file.write_text(
+        "\n".join(
+            [
+                "class Exp:",
+                "    def __init__(self):",
+                "        self.name = 'custom'",
+                "    def get_model(self):",
+                "        return 'model'",
+            ]
+        )
+    )
+
+    exp = get_exp_by_file(str(exp_file))
+    assert exp.name == "custom"
+    assert exp.get_model() == "model"


### PR DESCRIPTION
## Summary
- implement robust experiment loader under externals/ByteTrack/yolox
- update README examples to use integer class IDs
- add tests for new get_exp_by_file helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b2c242680832fb7d64ff4fd062cf0