### PR TITLE
fix: make detection image timezone non-interactive

### DIFF
--- a/Dockerfile.detect
+++ b/Dockerfile.detect
@@ -1,5 +1,9 @@
 FROM pytorch/pytorch:2.2.1-cuda12.1-cudnn8-runtime
 
+# Avoid interactive prompts when installing packages
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ffmpeg \
@@ -8,7 +12,10 @@ RUN apt-get update && \
         git \
         build-essential \
         libopencv-dev \
-        python3-dev && \
+        python3-dev \
+        tzdata && \
+    ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    dpkg-reconfigure --frontend noninteractive tzdata && \
     rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt /tmp/requirements.txt

--- a/README.md
+++ b/README.md
@@ -320,6 +320,39 @@ python -m src.validate_detections sanity-check \
 
 This prints the number of invalid bounding boxes and low-confidence detections.
 
+## Detection Docker Image
+
+- **Service name:** `decoder-detect`
+- **Purpose:** Run YOLOX detection and optional ByteTrack tracking on a directory of frames.
+- **GPU:** Required; enable with `--gpus all`.
+- **Volumes:** Mount project directory to `/app` to access frames and outputs.
+- **Build:**
+
+  ```bash
+  docker build -f Dockerfile.detect -t decoder-detect:latest .
+  ```
+
+- **Run:**
+
+  ```bash
+  docker run --gpus all --rm -v $(pwd):/app decoder-detect:latest \
+      detect --frames-dir /app/frames --output-json /app/detections.json
+  ```
+
+- **Parameters:**
+
+  | Option | Description | Default |
+  | ------ | ----------- | ------- |
+  | `--frames-dir` | Input PNG/JPG frames directory | **required** |
+  | `--output-json` | Path to save detection results | **required** |
+  | `--model` | YOLOX model size (`yolox-s` ... `yolox-x`) | `yolox-s` |
+  | `--img-size` | Inference image size | `640` |
+  | `--conf-thres` | Confidence threshold | `0.3` |
+  | `--nms-thres` | NMS threshold | `0.45` |
+  | `--classes` | Filter by class IDs | none |
+
+Tracking mode is available via `python -m src.detect_objects track` inside the container.
+
 ## Single Image Detection Demo
 
 A small container is provided to run YOLOX on a single image. Build it with:


### PR DESCRIPTION
## Summary
- prevent tzdata configuration prompts in `Dockerfile.detect`
- document `decoder-detect` service and parameters in `README`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898b56f5170832fafb2a7529ea5a024