### PR TITLE
Add thop dependency and clarify YOLOX usage

### DIFF
--- a/Dockerfile.detect
+++ b/Dockerfile.detect
@@ -32,7 +32,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
       (pip3 install --no-deps "yolox @ git+https://github.com/Megvii-BaseDetection/YOLOX.git@${YOLOX_REF}" \
        || (echo "[warn] YOLOX ref '${YOLOX_REF}' not found, falling back to 'main'" && \
            pip3 install --no-deps "yolox @ git+https://github.com/Megvii-BaseDetection/YOLOX.git@main")) && \
-      python - <<'PY' || true
+        bash -lc "python - <<'PY' || { echo '[warn] YOLOX smoke-check failed (non-fatal)'; exit 0; }
 import importlib, inspect
 import torch, torchvision
 print('torch:', torch.__version__, '| torchvision:', torchvision.__version__)
@@ -43,7 +43,7 @@ try:
     print('get_exp available:', True)
 except Exception as e:
     print('get_exp import failed:', e)
-PY
+PY"
 
 WORKDIR /app
 COPY . /app

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Run detection inside the container (assumes frames are in ``./frames``):
 
 ```bash
 docker run --gpus all --rm -v $(pwd):/app decoder-detect:latest \
-    --frames-dir frames/ \
+    detect --frames-dir frames/ \
     --output-json detections.json \
     --model yolox-s \
     --img-size 640 \
@@ -196,6 +196,10 @@ docker run --gpus all --rm -v $(pwd):/app decoder-detect:latest \
     --nms-thres 0.45 \
     --classes 0 32
 ```
+
+> **Note:** the image already has ENTRYPOINT `python -m src.detect_objects`.
+> Do not prefix the command with `python`; the first argument must be the
+> subcommand `detect` or `track`.
 
 Example ``detections.json`` output:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ scipy>=1.11        # needed by tracker.byte_tracker fallback
 shapely>=2.0
 tabulate>=0.9
 transformers>=4.53.0
+thop>=0.1.1

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -268,8 +268,13 @@ def _load_model(model_name: str):
         from yolox.exp import get_exp
         from yolox.utils import fuse_model
     except Exception as exc:  # pragma: no cover - missing package
+        msg = str(exc)
+        if "No module named 'thop'" in msg:
+            raise ImportError(
+                "YOLOX requires 'thop'. Add `thop>=0.1.1` to requirements and rebuild."
+            ) from exc
         raise ImportError(
-            "YOLOX modules not found. Install YOLOX from the official repository."
+            "YOLOX modules not found. Ensure official 'yolox' is installed."
         ) from exc
 
     variant = model_name.split("-", 1)[-1]


### PR DESCRIPTION
## Summary
- add `thop` to default dependencies
- provide clearer error when YOLOX fails due to missing `thop`
- document container entrypoint and print torch versions during detect image build

## Testing
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_6898f9d5f294832f85c8bde5e82defb1