### PR TITLE
feat: add Makefile pipeline targets and usage docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,46 @@
-.PHONY: test enhance build lint-imports
+.PHONY: detect-image track-image detect track pipeline clean-images smoke \
+        build test enhance lint-imports
 
+# Default YOLOX ref and Docker build settings.
+YOLOX_REF ?= 0.3.0
+DOCKER_BUILDKIT ?= 1
+PWD_ABS := $(shell pwd)
+
+detect-image:
+	@docker image inspect decoder-detect:latest >/dev/null 2>&1 || \
+	  (echo "==> Building decoder-detect (YOLOX_REF=$(YOLOX_REF))..." && \
+   DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build -f Dockerfile.detect \
+     --build-arg YOLOX_REF=$(YOLOX_REF) -t decoder-detect:latest .)
+
+track-image:
+	@docker image inspect decoder-track:latest >/dev/null 2>&1 || \
+	  (echo "==> Building decoder-track..." && \
+   DOCKER_BUILDKIT=$(DOCKER_BUILDKIT) docker build -f Dockerfile.track \
+     -t decoder-track:latest .)
+
+detect: detect-image
+	@echo "==> Running detection..."
+	docker run --gpus all --rm -v $(PWD_ABS):/app decoder-detect:latest \
+  detect --frames-dir /app/frames --output-json /app/detections.json \
+  --model yolox-x --img-size 1280
+
+track: track-image
+	@echo "==> Running tracking..."
+	docker run --gpus all --rm -v $(PWD_ABS):/app decoder-track:latest \
+  track --detections-json /app/detections.json --output-json /app/tracks.json
+
+pipeline: detect track
+	@echo "==> Done. Outputs: detections.json, tracks.json"
+
+smoke: detect-image track-image
+	@echo "==> Smoke: building only (no GPU run in CI)."
+	@echo "   decoder-detect and decoder-track images exist."
+
+clean-images:
+	@echo "==> Removing local decoder images..."
+	-@docker rmi -f decoder-detect:latest decoder-track:latest 2>/dev/null || true
+
+# Legacy targets retained for development.
 build:
 	docker build -t decoder-poc .
 
@@ -11,4 +52,5 @@ enhance:
 
 lint-imports:
 	@! git grep -nE '(^|[^A-Za-z_])(from|import)\s+yolox(\.|$$)' externals/ByteTrack | grep -v 'bytetrack_vendor' || \
-	 (echo "ERROR: found stray 'yolox' imports inside vendor"; exit 1)
+ (echo "ERROR: found stray 'yolox' imports inside vendor"; exit 1)
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 This project contains experimental utilities for video processing. The `frame_extractor` CLI provides a simple way to extract video frames using FFmpeg.
 
+## Quick pipeline (recommended)
+
+To avoid "image not found" errors, use the Makefile targets that auto-build images:
+
+```bash
+# build both images if missing, then run detect -> track
+make pipeline
+```
+
+You can override YOLOX ref at build time:
+```bash
+make detect-image YOLOX_REF=0.3.0
+```
+
 ## Frame Extraction CLI
 
 ```
@@ -197,9 +211,9 @@ docker run --gpus all --rm -v $(pwd):/app decoder-detect:latest \
     --classes 0 32
 ```
 
-> **Note:** the image already has ENTRYPOINT `python -m src.detect_objects`.
-> Do not prefix the command with `python`; the first argument must be the
-> subcommand `detect` or `track`.
+> **Note:** The images use `ENTRYPOINT ["python","-m","src.detect_objects"]`.
+> For ad-hoc python commands inside the container, override entrypoint:
+> `docker run --rm --entrypoint python decoder-detect:latest -c "import torch; print(torch.__version__)"`.
 
 Example ``detections.json`` output:
 
@@ -370,9 +384,9 @@ This prints the number of invalid bounding boxes and low-confidence detections.
       detect --frames-dir /app/frames --output-json /app/detections.json
   ```
 
-> **Note:** The image sets `ENTRYPOINT ["python","-m","src.detect_objects"]`.
-> For one-off Python commands use:
-> `docker run --rm --entrypoint python decoder-detect:latest -c "import yolox; print(yolox.__file__)"`.
+> **Note:** The images use `ENTRYPOINT ["python","-m","src.detect_objects"]`.
+> For ad-hoc python commands inside the container, override entrypoint:
+> `docker run --rm --entrypoint python decoder-detect:latest -c "import torch; print(torch.__version__)"`.
 
 - **Parameters:**
 


### PR DESCRIPTION
## Summary
- ensure decoder-detect and decoder-track images auto-build before running
- add one-step detect/track pipeline and smoke build target
- document Makefile usage and ENTRYPOINT override

## Testing
- `pytest -vv`
- `make smoke` *(fails: `/bin/sh: 3: docker: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6899973a89c8832f85ec075345de0cdf