### PR TITLE
feat: default to yolox-x model for detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Run detection inside the container (assumes frames are in ``./frames``):
 docker run --gpus all --rm -v $(pwd):/app decoder-detect:latest \
     detect --frames-dir frames/ \
     --output-json detections.json \
-    --model yolox-s \
+    --model yolox-x \
     --img-size 640 \
     --conf-thres 0.30 \
     --nms-thres 0.45 \
@@ -422,7 +422,7 @@ This prints the number of invalid bounding boxes and low-confidence detections.
   | ------ | ----------- | ------- |
   | `--frames-dir` | Input JPG/JPEG/PNG frames directory | **required** |
   | `--output-json` | Path to save detection results | **required** |
-  | `--model` | YOLOX model size (`yolox-s` ... `yolox-x`) | `yolox-s` |
+  | `--model` | YOLOX model size (`yolox-s` ... `yolox-x`) | `yolox-x` |
   | `--img-size` | Inference image size | `640` |
   | `--conf-thres` | Confidence threshold | `0.3` |
   | `--nms-thres` | NMS threshold | `0.45` |

--- a/src/detect_image.py
+++ b/src/detect_image.py
@@ -119,7 +119,7 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--model",
         type=str,
-        default="yolox-s",
+        default="yolox-x",
         choices=sorted(dobj.YOLOX_MODELS),
         help="YOLOX model variant",
     )

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -229,7 +229,7 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     det.add_argument("--frames-dir", type=Path, required=True)
     det.add_argument("--output-json", type=Path, required=True)
     det.add_argument(
-        "--model", type=str, default="yolox-s", choices=sorted(YOLOX_MODELS)
+        "--model", type=str, default="yolox-x", choices=sorted(YOLOX_MODELS)
     )
     det.add_argument("--img-size", type=int, default=640)
     det.add_argument("--conf-thres", type=float, default=0.3)

--- a/tests/test_detect_image.py
+++ b/tests/test_detect_image.py
@@ -66,7 +66,7 @@ import src.detect_image as di
 def test_parse_args_defaults() -> None:
     args = di.parse_args(["--image", "img.jpg"])
     assert isinstance(args, argparse.Namespace)
-    assert args.model == "yolox-s"
+    assert args.model == "yolox-x"
     assert args.img_size == 640
 
 

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -80,7 +80,7 @@ def test_parse_args_defaults() -> None:
         ]
     )
     assert isinstance(args, argparse.Namespace)
-    assert args.model == "yolox-s"
+    assert args.model == "yolox-x"
     assert args.img_size == 640
     assert args.classes is None
     assert args.two_pass is True


### PR DESCRIPTION
## Summary
- default to YOLOX-X model in detection CLI
- adjust image detection defaults and tests accordingly
- document YOLOX-X as the default model in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a46e9f65a0832fb2da42a8b8e84405