### PR TITLE
Improve tennis detection and tracking

### DIFF
--- a/src/ball_temporal_link.py
+++ b/src/ball_temporal_link.py
@@ -1,0 +1,110 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Temporal linking utilities for tennis ball detections.
+
+This module fills short gaps in ``sports ball`` detections by linear
+interpolation and removes stationary false positives (e.g. scoreboard icons).
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import re
+
+
+def _extract_frame_id(val) -> int | None:
+    match = re.findall(r"\d+", str(val))
+    return int(match[-1]) if match else None
+
+
+def _center(bbox: List[float]) -> tuple[float, float]:
+    x0, y0, x1, y1 = bbox
+    return (x0 + x1) / 2.0, (y0 + y1) / 2.0
+
+
+def link_ball_detections(entries: List[dict]) -> None:
+    """In-place interpolation of missing ball detections.
+
+    Parameters
+    ----------
+    entries:
+        Detection results in nested format ``[{"frame": str, "detections": [...]}, ...]``.
+    """
+
+    balls: List[tuple[int, dict]] = []
+    for entry in entries:
+        frame_id = _extract_frame_id(entry.get("frame")) or 0
+        for det in entry.get("detections", []):
+            if det.get("class") == _class_id_ball():
+                balls.append((frame_id, det))
+
+    balls.sort(key=lambda x: x[0])
+
+    # Interpolate gaps
+    for idx in range(len(balls) - 1, 0, -1):
+        f0, d0 = balls[idx - 1]
+        f1, d1 = balls[idx]
+        gap = f1 - f0
+        if 1 < gap <= 3:
+            c0 = _center(d0["bbox"])
+            c1 = _center(d1["bbox"])
+            for step in range(1, gap):
+                nx = c0[0] + (c1[0] - c0[0]) * step / gap
+                ny = c0[1] + (c1[1] - c0[1]) * step / gap
+                w = d0["bbox"][2] - d0["bbox"][0]
+                h = d0["bbox"][3] - d0["bbox"][1]
+                bbox = [nx - w / 2, ny - h / 2, nx + w / 2, ny + h / 2]
+                balls.insert(
+                    idx,
+                    (
+                        f0 + step,
+                        {
+                            "bbox": bbox,
+                            "score": 0.25,
+                            "class": d0["class"],
+                            "interpolated": True,
+                        },
+                    ),
+                )
+
+    # Remove stationary sequences (>5 frames with <1px movement)
+    filtered: List[tuple[int, dict]] = []
+    last_c = None
+    stationary = 0
+    for f, det in balls:
+        c = _center(det["bbox"])
+        if last_c and (abs(c[0] - last_c[0]) <= 1 and abs(c[1] - last_c[1]) <= 1):
+            stationary += 1
+        else:
+            stationary = 0
+        last_c = c
+        if stationary >= 5:
+            continue
+        filtered.append((f, det))
+
+    # Rebuild nested entries
+    per_frame: dict[int, List[dict]] = {}
+    for f, det in filtered:
+        per_frame.setdefault(f, []).append(det)
+    for entry in entries:
+        fid = _extract_frame_id(entry.get("frame")) or 0
+        entry["detections"].extend(per_frame.get(fid, []))
+
+
+def _class_id_ball() -> int:
+    from .utils.classes import CLASS_NAME_TO_ID
+
+    return CLASS_NAME_TO_ID["sports ball"]
+
+
+__all__ = ["link_ball_detections"]

--- a/src/track_objects.py
+++ b/src/track_objects.py
@@ -1,0 +1,223 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ByteTrack based tracking for person and ball detections."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from loguru import logger
+
+from .detect_objects import (
+    _extract_frame_id,
+    _normalize_bbox,
+    _update_tracker,
+    CLASS_ID_TO_NAME,
+    CLASS_NAME_TO_ID,
+    CLASS_ALIASES,
+    _norm,
+    _get_tlwh_from_track,
+)
+
+
+def _load_detections_grouped(
+    path: Path, min_score: float
+) -> Dict[int, Dict[int, List[dict]]]:
+    """Return detections grouped by frame and class.
+
+    Logs a warning if frame indices are not strictly increasing in the source
+    file but always returns a numerically sorted dictionary.
+    """
+
+    with path.open() as fh:
+        raw = json.load(fh)
+
+    if not isinstance(raw, list):
+        raise ValueError("detections-json must contain a list")
+
+    frames: Dict[int, Dict[int, List[dict]]] = {}
+    prev = -1
+    for item in raw:
+        frame_id = _extract_frame_id(item.get("frame"))
+        if frame_id is None:
+            continue
+        if frame_id < prev:
+            logger.warning("Out-of-order frame %s after %s", frame_id, prev)
+        prev = frame_id
+        cls_val = item.get("class")
+        if isinstance(cls_val, str):
+            cls_key = CLASS_ALIASES.get(_norm(cls_val), _norm(cls_val))
+            if cls_key not in CLASS_NAME_TO_ID:
+                continue
+            cls_id = CLASS_NAME_TO_ID[cls_key]
+        else:
+            cls_id = int(cls_val)
+            if cls_id not in CLASS_ID_TO_NAME:
+                continue
+        score = float(item.get("score", 0.0))
+        if score < min_score:
+            continue
+        bbox = _normalize_bbox(item.get("bbox"))
+        if bbox is None:
+            continue
+        frames.setdefault(frame_id, {}).setdefault(cls_id, []).append(
+            {"bbox": bbox, "score": score}
+        )
+
+    return dict(sorted(frames.items()))
+
+
+def track_detections(
+    detections_json: Path,
+    output_json: Path,
+    min_score: float,
+    fps: int,
+    reid_reuse_window: int,
+    p_track_thresh: float,
+    p_high_thresh: float,
+    p_match_thresh: float,
+    p_track_buffer: int,
+    b_track_thresh: float,
+    b_high_thresh: float,
+    b_match_thresh: float,
+    b_track_buffer: int,
+    b_min_box_area: float,
+    b_max_aspect_ratio: float,
+) -> None:
+    """Track detections for persons and balls separately."""
+
+    from bytetrack_vendor.tracker.byte_tracker import BYTETracker
+
+    frames = _load_detections_grouped(detections_json, min_score)
+
+    logger.info("tracking order: numeric by frame_index")
+
+    trackers = {
+        CLASS_NAME_TO_ID["person"]: BYTETracker(
+            track_thresh=p_track_thresh,
+            high_thresh=p_high_thresh,
+            match_thresh=p_match_thresh,
+            track_buffer=p_track_buffer,
+            frame_rate=fps,
+        ),
+        CLASS_NAME_TO_ID["sports ball"]: BYTETracker(
+            track_thresh=b_track_thresh,
+            high_thresh=b_high_thresh,
+            match_thresh=b_match_thresh,
+            track_buffer=b_track_buffer,
+            frame_rate=fps,
+        ),
+    }
+
+    active: Dict[int, Dict[int, Tuple[List[float], int]]] = {
+        cid: {} for cid in trackers
+    }
+    reuse: Dict[int, List[dict]] = {cid: [] for cid in trackers}
+
+    out: List[dict] = []
+
+    for frame_id in sorted(frames):
+        for cls_id, tracker in trackers.items():
+            dets = frames[frame_id].get(cls_id, [])
+            if cls_id == CLASS_NAME_TO_ID["sports ball"]:
+                dets = [
+                    d
+                    for d in dets
+                    if (d["bbox"][2] - d["bbox"][0]) * (d["bbox"][3] - d["bbox"][1])
+                    >= b_min_box_area
+                    and (
+                        (d["bbox"][2] - d["bbox"][0])
+                        / max(d["bbox"][3] - d["bbox"][1], 1e-3)
+                    )
+                    <= b_max_aspect_ratio
+                ]
+            tlwhs = [
+                (
+                    b[0],
+                    b[1],
+                    b[2] - b[0],
+                    b[3] - b[1],
+                )
+                for b in [d["bbox"] for d in dets]
+            ]
+            scores = [d["score"] for d in dets]
+            classes = [cls_id] * len(dets)
+            tracks = _update_tracker(tracker, tlwhs, scores, classes, frame_id)
+
+            current_ids = set()
+            for tr in tracks:
+                bbox = list(_get_tlwh_from_track(tr))
+                tid = getattr(tr, "track_id", id(tr))
+                reuse_id = _reuse_id(reuse[cls_id], bbox, frame_id, reid_reuse_window)
+                if reuse_id is not None:
+                    tid = reuse_id
+                out.append(
+                    {
+                        "frame": frame_id,
+                        "class": cls_id,
+                        "bbox": [
+                            bbox[0],
+                            bbox[1],
+                            bbox[0] + bbox[2],
+                            bbox[1] + bbox[3],
+                        ],
+                        "score": float(getattr(tr, "score", 1.0)),
+                        "track_id": tid,
+                    }
+                )
+                active[cls_id][tid] = (bbox, frame_id)
+                current_ids.add(tid)
+
+            vanished = set(active[cls_id]) - current_ids
+            for vid in vanished:
+                bbox, last_frame = active[cls_id].pop(vid)
+                reuse[cls_id].append({"id": vid, "bbox": bbox, "frame": last_frame})
+            reuse[cls_id] = [
+                r for r in reuse[cls_id] if frame_id - r["frame"] <= reid_reuse_window
+            ]
+
+    out.sort(key=lambda d: (d["frame"], d["class"], d["track_id"]))
+    with output_json.open("w") as fh:
+        json.dump(out, fh, indent=2)
+
+
+def _reuse_id(
+    cache: List[dict], bbox: List[float], frame_id: int, window: int
+) -> int | None:
+    """Return cached ID if ``bbox`` matches a recently vanished track."""
+
+    x, y, w, h = bbox
+    for item in cache:
+        if frame_id - item["frame"] > window:
+            continue
+        iou = _iou(bbox, item["bbox"])
+        if iou >= 0.6:
+            cache.remove(item)
+            return item["id"]
+    return None
+
+
+def _iou(b1: List[float], b2: List[float]) -> float:
+    x1, y1, w1, h1 = b1
+    x2, y2, w2, h2 = b2
+    xa = max(x1, x2)
+    ya = max(y1, y2)
+    xb = min(x1 + w1, x2 + w2)
+    yb = min(y1 + h1, y2 + h2)
+    inter = max(0.0, xb - xa) * max(0.0, yb - ya)
+    union = w1 * h1 + w2 * h2 - inter
+    return inter / union if union else 0.0
+
+
+__all__ = ["track_detections", "_load_detections_grouped"]

--- a/tests/test_detect_cli.py
+++ b/tests/test_detect_cli.py
@@ -1,0 +1,51 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for CLI alias support in detect_objects."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+sys.modules.setdefault("torch", types.SimpleNamespace())
+sys.modules.setdefault("numpy", types.SimpleNamespace())
+
+from src.detect_objects import parse_args  # noqa: E402
+
+
+def _base_args() -> list[str]:
+    """Return required base CLI arguments."""
+
+    return ["detect", "--frames-dir", "f", "--output-json", "o"]
+
+
+def test_person_conf_alias() -> None:
+    """Verify that person confidence alias flags parse correctly."""
+
+    ns = parse_args(_base_args() + ["--person-conf", "0.7"])
+    assert ns.person_conf == 0.7
+
+    ns_alias = parse_args(_base_args() + ["--conf-person", "0.8"])
+    assert ns_alias.person_conf == 0.8
+
+
+def test_ball_conf_alias() -> None:
+    """Verify that ball confidence alias flags parse correctly."""
+
+    ns = parse_args(_base_args() + ["--ball-conf", "0.2"])
+    assert ns.ball_conf == 0.2
+
+    ns_alias = parse_args(_base_args() + ["--conf-ball", "0.3"])
+    assert ns_alias.ball_conf == 0.3

--- a/tests/test_frame_sort.py
+++ b/tests/test_frame_sort.py
@@ -1,0 +1,48 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for numeric frame sorting utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+cv2_stub = types.SimpleNamespace(FONT_HERSHEY_SIMPLEX=0, LINE_AA=0)
+sys.modules.setdefault("cv2", cv2_stub)
+sys.modules.setdefault("torch", types.SimpleNamespace())
+sys.modules.setdefault("numpy", types.SimpleNamespace(ndarray=object))
+
+from src.utils.draw_helpers import load_frames  # noqa: E402
+from src.track_objects import _load_detections_grouped  # noqa: E402
+
+
+def test_load_frames_numeric(tmp_path: Path) -> None:
+    (tmp_path / "frame_10.png").write_text("a")
+    (tmp_path / "frame_2.png").write_text("a")
+    (tmp_path / "frame_1.png").write_text("a")
+    frames = load_frames(tmp_path)
+    assert [f.name for f in frames] == ["frame_1.png", "frame_2.png", "frame_10.png"]
+
+
+def test_detection_loading_warns(monkeypatch, tmp_path: Path, caplog) -> None:
+    data = [
+        {"frame": "frame_10.png", "class": 0, "bbox": [0, 0, 1, 1], "score": 0.9},
+        {"frame": "frame_2.png", "class": 0, "bbox": [0, 0, 1, 1], "score": 0.9},
+    ]
+    jpath = tmp_path / "dets.json"
+    jpath.write_text(json.dumps(data))
+    grouped = _load_detections_grouped(jpath, 0.1)
+    assert list(grouped.keys()) == [2, 10]

--- a/tests/test_roi_filter.py
+++ b/tests/test_roi_filter.py
@@ -1,0 +1,70 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for ROI filtering during detection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+class DummyPoint:
+    def __init__(self, x: float, y: float) -> None:
+        self.x = x
+        self.y = y
+
+
+class DummyPolygon:
+    def __init__(self, pts: list[tuple[float, float]]) -> None:
+        xs, ys = zip(*pts)
+        self.x0, self.y0 = min(xs), min(ys)
+        self.x1, self.y1 = max(xs), max(ys)
+
+    def buffer(self, margin: float) -> "DummyPolygon":
+        return DummyPolygon(
+            [
+                (self.x0 - margin, self.y0 - margin),
+                (self.x1 + margin, self.y1 + margin),
+            ]
+        )
+
+    def contains(self, point: DummyPoint) -> bool:
+        return self.x0 <= point.x <= self.x1 and self.y0 <= point.y <= self.y1
+
+
+geometry = types.SimpleNamespace(Polygon=DummyPolygon, Point=DummyPoint)
+shapely_stub = types.SimpleNamespace(geometry=geometry)
+sys.modules.setdefault("shapely", shapely_stub)
+sys.modules.setdefault("shapely.geometry", geometry)
+sys.modules.setdefault("torch", types.SimpleNamespace())
+sys.modules.setdefault("numpy", types.SimpleNamespace(ndarray=object))
+from shapely.geometry import Polygon  # type: ignore  # noqa: E402
+from src.detect_objects import _filter_by_roi  # noqa: E402
+
+
+def test_filter_by_roi_keeps_inside() -> None:
+    poly = Polygon([(0, 0), (100, 0), (100, 100), (0, 100)])
+    entries = [
+        {
+            "frame": "frame_1.png",
+            "detections": [
+                {"bbox": [10, 10, 20, 20], "class": 0},
+                {"bbox": [150, 150, 160, 160], "class": 0},
+            ],
+        }
+    ]
+    filtered = _filter_by_roi(entries, poly, 0, False)
+    dets = filtered[0]["detections"]
+    assert len(dets) == 1 and dets[0]["bbox"] == [10, 10, 20, 20]


### PR DESCRIPTION
## Summary
- add class-specific detection thresholds, ROI filtering, and ball gap interpolation
- introduce separate ByteTrack instances with sticky IDs for players and balls
- extend overlay to respect court ROI and highlight primary player
- add numeric frame sorting and ROI unit tests
- rename detection confidence flags to `--person-conf`/`--ball-conf` with legacy aliases and document them

## Testing
- `ruff check tests/test_frame_sort.py tests/test_roi_filter.py tests/test_detect_cli.py src/detect_objects.py --fix`
- `black tests/test_frame_sort.py tests/test_roi_filter.py tests/test_detect_cli.py src/detect_objects.py`
- `pytest tests/test_frame_sort.py tests/test_roi_filter.py tests/test_detect_cli.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a477c9dc00832fb278eb8f08fd23d9