### PR TITLE
fix: include loguru in draw image

### DIFF
--- a/Dockerfile.draw
+++ b/Dockerfile.draw
@@ -10,6 +10,6 @@ COPY src/ /app/src
 
 # Minimal dependencies for headless rendering
 RUN python -m pip install --upgrade pip && \
-    pip install --no-cache-dir opencv-python-headless pillow numpy
+    pip install --no-cache-dir opencv-python-headless pillow numpy loguru
 
 ENTRYPOINT ["tini", "--", "python", "-m", "src.draw_overlay"]

--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ draw   -> overlays in out/frames_viz and optional MP4
 ```
 
 Image name: `decoder-draw:latest` (CPU only). Mount the repository as `/app`.
+Includes `loguru` (>=0.7.0) for logging.
 Parameters: run `docker run --rm decoder-draw:latest --help`.
 Modes: `--mode auto|detect|track` (default `auto` picks `track` if `--tracks-json` exists, otherwise `detect`).
 


### PR DESCRIPTION
## Summary
- install `loguru` in the `decoder-draw` container
- document logging dependency in README

## Testing
- `pytest`
- `docker build -t decoder-draw:latest -f Dockerfile.draw .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c210fa1c832fa6d3d825b7eb87cf