### PR TITLE
feat: tennis tuning defaults for detect/track + ROI gate + stitching

### DIFF
--- a/src/ball_temporal_link.py
+++ b/src/ball_temporal_link.py
@@ -32,13 +32,15 @@ def _center(bbox: List[float]) -> tuple[float, float]:
     return (x0 + x1) / 2.0, (y0 + y1) / 2.0
 
 
-def link_ball_detections(entries: List[dict]) -> None:
+def link_ball_detections(entries: List[dict], gap_max: int = 5) -> None:
     """In-place interpolation of missing ball detections.
 
     Parameters
     ----------
     entries:
         Detection results in nested format ``[{"frame": str, "detections": [...]}, ...]``.
+    gap_max:
+        Maximum gap in frames to interpolate.  # tennis tuning
     """
 
     balls: List[tuple[int, dict]] = []
@@ -55,7 +57,7 @@ def link_ball_detections(entries: List[dict]) -> None:
         f0, d0 = balls[idx - 1]
         f1, d1 = balls[idx]
         gap = f1 - f0
-        if 1 < gap <= 3:
+        if 1 < gap <= gap_max:  # tennis tuning
             c0 = _center(d0["bbox"])
             c1 = _center(d1["bbox"])
             for step in range(1, gap):
@@ -78,6 +80,7 @@ def link_ball_detections(entries: List[dict]) -> None:
                 )
 
     # Remove stationary sequences (>5 frames with <1px movement)
+    # tennis tuning: filters scoreboard or lamp artifacts
     filtered: List[tuple[int, dict]] = []
     last_c = None
     stationary = 0

--- a/tests/test_detect_objects.py
+++ b/tests/test_detect_objects.py
@@ -86,8 +86,9 @@ def test_parse_args_defaults() -> None:
     assert args.two_pass is True
     assert args.person_conf == 0.55
     assert args.person_img_size == 1280
-    assert args.ball_conf == 0.15
-    assert args.ball_img_size == 1536
+    assert args.ball_conf == 0.10
+    assert args.ball_img_size == 1280
+    assert args.ball_interp_gap_max == 5
     assert args.save_splits is False
 
 

--- a/tests/test_draw_overlay.py
+++ b/tests/test_draw_overlay.py
@@ -26,6 +26,7 @@ cv2_dummy.imread = lambda *a, **k: None
 cv2_dummy.imwrite = lambda *a, **k: True
 cv2_dummy.rectangle = lambda *a, **k: None
 cv2_dummy.putText = lambda *a, **k: None
+cv2_dummy.polylines = lambda *a, **k: None
 cv2_dummy.FONT_HERSHEY_SIMPLEX = 0
 cv2_dummy.LINE_AA = 16
 sys.modules.setdefault('cv2', cv2_dummy)

--- a/tests/test_roi_filter.py
+++ b/tests/test_roi_filter.py
@@ -43,6 +43,14 @@ class DummyPolygon:
     def contains(self, point: DummyPoint) -> bool:
         return self.x0 <= point.x <= self.x1 and self.y0 <= point.y <= self.y1
 
+    @property
+    def bounds(self) -> tuple[float, float, float, float]:
+        return self.x0, self.y0, self.x1, self.y1
+
+    @property
+    def area(self) -> float:
+        return (self.x1 - self.x0) * (self.y1 - self.y0)
+
 
 geometry = types.SimpleNamespace(Polygon=DummyPolygon, Point=DummyPoint)
 shapely_stub = types.SimpleNamespace(geometry=geometry)

--- a/tests/test_verify_tennis_defaults.py
+++ b/tests/test_verify_tennis_defaults.py
@@ -1,0 +1,35 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`tools.verify_tennis_defaults`."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from tools.verify_tennis_defaults import _metrics  # noqa: E402
+
+
+def test_metrics_computation(tmp_path: Path) -> None:
+    data = [
+        {"frame": 1, "class": 0, "track_id": 1},
+        {"frame": 1, "class": 32, "track_id": 5},
+        {"frame": 2, "class": 32, "track_id": 5},
+        {"frame": 2, "class": 0, "track_id": 2},
+    ]
+    players, frac_ball, avg_ball = _metrics(data)
+    assert players == 2
+    assert frac_ball == 1.0
+    assert avg_ball == 2.0

--- a/tools/verify_tennis_defaults.py
+++ b/tools/verify_tennis_defaults.py
@@ -1,0 +1,67 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sanity checks for tennis tracking outputs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Set
+
+
+def _metrics(tracks: list[dict]) -> tuple[int, float, float]:
+    """Return (unique players, fraction of frames with ball, avg ball track length).
+
+    Args:
+        tracks: Flat list of track dictionaries.
+    """  # tennis tuning
+
+    person_ids: Set[int] = set()
+    ball_frames: Set[int] = set()
+    ball_tracks: Dict[int, Set[int]] = {}
+    all_frames: Set[int] = set()
+    for det in tracks:
+        frame = int(det.get("frame", 0))
+        cls = det.get("class")
+        tid = det.get("track_id")
+        all_frames.add(frame)
+        if cls in (0, "person") and tid is not None:
+            person_ids.add(int(tid))
+        if cls in (32, "sports ball") and tid is not None:
+            ball_frames.add(frame)
+            ball_tracks.setdefault(int(tid), set()).add(frame)
+    frac_ball = (len(ball_frames) / len(all_frames)) if all_frames else 0.0
+    avg_ball = (
+        sum(len(v) for v in ball_tracks.values()) / len(ball_tracks)
+        if ball_tracks
+        else 0.0
+    )
+    return len(person_ids), frac_ball, avg_ball
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry point."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tracks-json", type=Path, required=True)
+    args = parser.parse_args(argv)
+    with args.tracks_json.open() as fh:
+        data = json.load(fh)
+    players, frac_ball, avg_ball = _metrics(data)
+    print(
+        f"players={players} ball_frame_frac={frac_ball:.2f} avg_ball_track={avg_ball:.1f}"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()


### PR DESCRIPTION
## Summary
- improve ROI handling with tennis-court polygon, ball interpolation, and summary logging
- retune tracking defaults and add half-court gating
- draw court outline and expose only-court option in overlay
- document tennis defaults, provide verify script, and hotfix imports

## Testing
- `pytest -q`
- `python -m src.detect_objects --help | head -n 20`
- `python -m src.detect_objects track --help | head -n 20`
- `python -m src.draw_overlay --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a709a900d8832fb9d29864081866fb