### PR TITLE
fix(draw_overlay): accept court.json (list) in --roi-json; docs: clarify ROI list support

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ docker run --rm -v "$(pwd)":/app --entrypoint python decoder-track:latest \
 
 Use `--draw-court=false` to hide the court polygon.
 
+`--roi-json` accepts either a single polygon `{ "polygon": [...] }` or a `court.json` file with per-frame polygons (the polygon from the first frame is used).
+
 - `--only-court`: Draw only the court contour without boxes or IDs.
 - `--palette-seed`: Stabilise the colour palette globally.
 - `--class-map`: Optional JSON/YAML mapping of class IDs to names.


### PR DESCRIPTION
## Summary
- allow draw_overlay to load ROI polygon from dict or per-frame list JSON
- test tolerant ROI loader in draw_overlay
- clarify ROI list support in README

## Testing
- `pytest tests/test_draw_overlay.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72e8308b0832fac690cab778b3c5e