### PR TITLE
Improve MP4 export robustness and CRF handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,19 @@ docker run --rm -v "$(pwd)":/app --entrypoint python decoder-track:latest \
   --tracks-json /app/tracks.json \
   --output-dir /app/preview_tracks \
   --export-mp4 /app/preview_tracks.mp4 --fps 25 --draw-court --draw-court-lines --roi-json /app/court.json
+
+# Disable CRF if ffmpeg lacks support
+docker run --rm -v "$(pwd)":/app --entrypoint python decoder-track:latest \
+  -m src.draw_overlay \
+  --mode track \
+  --frames-dir /app/frames \
+  --tracks-json /app/tracks.json \
+  --output-dir /app/preview_tracks \
+  --export-mp4 /app/preview_tracks.mp4 --fps 25 --crf -1 --draw-court --draw-court-lines --roi-json /app/court.json
 ```
+
+If your ffmpeg build does not support `-crf`, use `--crf -1` or install a full
+ffmpeg with libx264.
 
 Запускати можна всередині будь-якого образу, де є Python + OpenCV. Найпростіше — у decoder-track:latest з примонтованим репозиторієм:
 
@@ -508,6 +520,9 @@ python -m src.draw_tracks \
     --output-video out.mp4 \
     --fps 30
 ```
+
+If your ffmpeg build does not support `-crf`, use `--crf -1` or install a full
+ffmpeg with libx264.
 
 | Option | Description |
 | ------ | ----------- |
@@ -862,14 +877,17 @@ docker run --gpus all --rm -v "$(pwd)":/app decoder-track:latest \
         --smooth ema --smooth-alpha 0.3
 
 # 4) overlay preview (PNG + MP4)
-docker run --rm -v "$(pwd)":/app --entrypoint python decoder-track:latest \
-  -m src.draw_overlay \
-    --mode track \
-    --frames-dir /app/frames \
-    --tracks-json /app/tracks.json \
-    --output-dir /app/preview_tracks \
-    --export-mp4 /app/preview_tracks.mp4 --fps 25 \
-    --draw-court --draw-court-lines --roi-json /app/court.json
+  docker run --rm -v "$(pwd)":/app --entrypoint python decoder-track:latest \
+    -m src.draw_overlay \
+      --mode track \
+      --frames-dir /app/frames \
+      --tracks-json /app/tracks.json \
+      --output-dir /app/preview_tracks \
+      --export-mp4 /app/preview_tracks.mp4 --fps 25 \
+      --draw-court --draw-court-lines --roi-json /app/court.json
+
+If your ffmpeg build does not support `-crf`, add `--crf -1` or install a full
+ffmpeg with libx264.
 
 # 5) sanity metrics
 docker run --rm -v "$(pwd)":/app decoder-track:latest \


### PR DESCRIPTION
## Summary
- make MP4 export resilient to missing `-crf` or `libx264` and switch to mpeg4 when necessary
- expose `--crf` flag with disable option and document ffmpeg fallback scenarios
- test MP4 command generation and CRF fallback behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74dd85228832f96a386b7481cc284