### PR TITLE
feat: add optional court weights provisioning

### DIFF
--- a/Dockerfile.court
+++ b/Dockerfile.court
@@ -21,5 +21,35 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 WORKDIR /app
 COPY . /app
+ENV COURT_WEIGHTS=/app/model.pt
+RUN set -eux; \
+    mkdir -p /app/scripts; \
+    if [ -s "/app/weights/model.pt" ]; then \
+        cp -v "/app/weights/model.pt" "$COURT_WEIGHTS"; \
+    elif [ -s "/app/services/court_detector/weights/model.pt" ]; then \
+        cp -v "/app/services/court_detector/weights/model.pt" "$COURT_WEIGHTS"; \
+    else \
+        echo "WARNING: court weights not found in /app/weights/model.pt. You can bind-mount and pass --weights /app/model.pt at runtime."; \
+    fi; \
+    cat <<'EOF' > /app/scripts/check_court_weights.sh; \
+#!/usr/bin/env bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+if [ -s "$COURT_WEIGHTS" ]; then
+  stat -c "%n %s bytes" "$COURT_WEIGHTS"
+else
+  echo "missing $COURT_WEIGHTS" >&2
+  exit 1
+fi
+EOF
+    chmod +x /app/scripts/check_court_weights.sh
 
 ENTRYPOINT ["python", "-m", "src.court_detector"]

--- a/README.md
+++ b/README.md
@@ -810,6 +810,57 @@ docker run --rm -v "$(pwd)":/app decoder-court:latest \
 - Provide `--weights /app/weights/tcd.pth`; without weights, add `--allow-placeholder` to emit a full-frame placeholder
   (real geometry is recommended for gating and line rendering)
 
+### Court weights
+
+Download the pretrained TennisCourtDetector checkpoint from the official
+repository and save it as `./weights/model.pt`.
+Original weights (Google Drive):
+https://drive.google.com/file/d/1f-Co64ehgq4uddcQm1aFBDtbnyZhQvgG/view?usp=drive_link
+
+After weights are available, the detector will pick them up automatically.
+
+#### A) Build-time include (preferred)
+
+```bash
+mkdir -p weights && cp /path/to/model.pt weights/model.pt
+DOCKER_BUILDKIT=1 docker build -f Dockerfile.court -t decoder-court:latest .
+docker run --rm --entrypoint bash decoder-court:latest -lc 'echo "$COURT_WEIGHTS"; ls -lh "$COURT_WEIGHTS"'
+docker run --rm -v "$(pwd)":/app decoder-court:latest \
+  --frames-dir /app/frames --output-json /app/court.json \
+  --device cuda --min-conf 0.05
+```
+
+#### B) Runtime bind-mount
+
+```bash
+docker run --rm \
+  -v "$(pwd)":/app \
+  -v "$(pwd)/weights/model.pt":/app/model.pt:ro \
+  decoder-court:latest \
+  --frames-dir /app/frames --output-json /app/court.json \
+  --weights /app/model.pt --device cuda --min-conf 0.05
+```
+
+Optional check:
+
+```bash
+docker run --rm --entrypoint bash decoder-court:latest -lc '/app/scripts/check_court_weights.sh || echo "weights missing"'
+```
+
+#### Acceptance criteria
+
+- [ ] Build succeeds whether or not `./weights/model.pt` exists.
+- [ ] If `./weights/model.pt` existed at build time, the file is visible inside the image:
+  ```bash
+  docker run --rm --entrypoint bash decoder-court:latest -lc 'echo "$COURT_WEIGHTS"; ls -lh "$COURT_WEIGHTS"'
+  ```
+- [ ] With frames and weights provided, the detector writes a non-empty `court.json`:
+  ```bash
+  docker run --rm -v "$(pwd)":/app decoder-court:latest \
+    --frames-dir /app/frames --output-json /app/court.json --device cuda --min-conf 0.05
+  head -n 20 court.json
+  ```
+
 ### Parameters
 
 | Option | Description | Default |


### PR DESCRIPTION
## Summary
- load court detector weights automatically if `weights/model.pt` is present
- document how to bake or bind-mount the pretrained TennisCourtDetector weights
- show example command using baked-in weights

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab1a7f9bb0832f938e44be56df3645