### PR TITLE
feat: add per-class detection thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,12 +625,12 @@ This prints the number of invalid bounding boxes and low-confidence detections.
   | `--court-use-homography` | Enable homography refinement (placeholder) | `false` |
   | `--court-refine-kps` | Enable keypoint refinement (placeholder) | `false` |
   | `--court-weights` | Optional path to court model weights | _none_ |
-  | `--person-conf` | Person detection confidence (alias: --conf-person) | `0.55` |
-  | `--person-nms` | Person NMS threshold | `0.45` |
+  | `--p-conf` | Person detection confidence | `0.35` |
+  | `--p-nms` | Person NMS threshold | `0.6` |
   | `--person-img-size` | Person inference image size | `1280` |
   | `--person-classes` | Person classes | `person` |
-  | `--ball-conf` | Ball detection confidence (alias: --conf-ball) | `0.15` |
-  | `--ball-nms` | Ball NMS threshold | `0.30` |
+  | `--b-conf` | Ball detection confidence | `0.05` |
+  | `--b-nms` | Ball NMS threshold | `0.7` |
   | `--ball-img-size` | Ball inference image size | `1536` |
   | `--ball-classes` | Ball classes | `"sports ball"` |
   | `--nms-class-aware` | Apply NMS per class | `true` |
@@ -729,8 +729,8 @@ Recommended thresholds for tennis court videos:
 
 | Flag | Person | Ball |
 | ---- | ------ | ---- |
-| `--person-conf` | 0.55 | - |
-| `--ball-conf` | - | 0.10 |
+| `--p-conf` | 0.35 | - |
+| `--b-conf` | - | 0.05 |
 | `--p-track-buffer` | 125 | - |
 | `--b-track-buffer` | - | 90 |
 
@@ -740,7 +740,7 @@ Example commands:
 docker run --gpus all --rm -v "$(pwd)":/app decoder-detect:latest \
   detect --frames-dir /app/frames --output-json /app/detections.json \
   --two-pass --model yolox-x \
-  --person-conf 0.55 --ball-conf 0.10 --nms-class-aware \
+  --p-conf 0.30 --b-conf 0.05 --p-nms 0.6 --b-nms 0.7 --nms-class-aware \
   --roi-json /app/court_meta.json --roi-margin 8
 
 docker run --gpus all --rm -v "$(pwd)":/app decoder-track:latest \

--- a/tests/test_detect_cli.py
+++ b/tests/test_detect_cli.py
@@ -9,18 +9,30 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for CLI alias support in detect_objects."""
+"""Tests for CLI argument handling in detect_objects."""
 
 from __future__ import annotations
 
 from pathlib import Path
 import sys
 import types
+from types import ModuleType
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-sys.modules.setdefault("torch", types.SimpleNamespace())
-sys.modules.setdefault("numpy", types.SimpleNamespace())
+# Provide lightweight stubs for optional dependencies
+try:  # pragma: no cover - optional import
+    import torch  # type: ignore
+except Exception:  # pragma: no cover
+    torch = ModuleType("torch")
+    torch.cuda = types.SimpleNamespace(is_available=lambda: True)
+    sys.modules["torch"] = torch
+    sys.modules.setdefault("torch.cuda", ModuleType("torch.cuda"))
+
+try:  # pragma: no cover - optional import
+    import numpy  # type: ignore
+except Exception:  # pragma: no cover
+    sys.modules["numpy"] = ModuleType("numpy")
 
 from src.detect_objects import parse_args  # noqa: E402
 
@@ -31,21 +43,45 @@ def _base_args() -> list[str]:
     return ["detect", "--frames-dir", "f", "--output-json", "o"]
 
 
-def test_person_conf_alias() -> None:
-    """Verify that person confidence alias flags parse correctly."""
+def test_per_class_conf_args() -> None:
+    """Verify that per-class confidence flags parse correctly."""
 
-    ns = parse_args(_base_args() + ["--person-conf", "0.7"])
-    assert ns.person_conf == 0.7
-
-    ns_alias = parse_args(_base_args() + ["--conf-person", "0.8"])
-    assert ns_alias.person_conf == 0.8
+    ns = parse_args(_base_args() + ["--p-conf", "0.7", "--b-conf", "0.2"])
+    assert ns.p_conf == 0.7
+    assert ns.b_conf == 0.2
 
 
-def test_ball_conf_alias() -> None:
-    """Verify that ball confidence alias flags parse correctly."""
+def test_conf_fallback() -> None:
+    """Ensure per-class confidences fall back to global threshold."""
 
-    ns = parse_args(_base_args() + ["--ball-conf", "0.2"])
-    assert ns.ball_conf == 0.2
+    ns = parse_args(_base_args() + ["--conf-thres", "0.4"])
+    assert ns.p_conf == 0.4
+    assert ns.b_conf == 0.4
 
-    ns_alias = parse_args(_base_args() + ["--conf-ball", "0.3"])
-    assert ns_alias.ball_conf == 0.3
+
+def test_aliases_still_work() -> None:
+    """Backward-compatible aliases must map to new args."""
+    ns = parse_args(
+        _base_args()
+        + [
+            "--person-conf",
+            "0.77",
+            "--conf-ball",
+            "0.11",
+            "--person-nms",
+            "0.55",
+            "--ball-nms",
+            "0.66",
+        ]
+    )
+    assert ns.p_conf == 0.77
+    assert ns.b_conf == 0.11
+    assert ns.p_nms == 0.55
+    assert ns.b_nms == 0.66
+
+
+def test_nms_fallback() -> None:
+    """Per-class NMS thresholds should inherit from --nms-thres if unset."""
+    ns = parse_args(_base_args() + ["--nms-thres", "0.42"])
+    assert ns.p_nms == 0.42
+    assert ns.b_nms == 0.42


### PR DESCRIPTION
## Summary
- raise default `--ball-img-size` to 1536 to match documentation
- add CLI tests covering legacy aliases and NMS fallback
- skip object-detection tests when torch/numpy are unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab49150d90832f92b7ff4e835c73c6