### PR TITLE
feat: enable functional multi-scale detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,33 @@ Example output:
 
 The script requires FFmpeg to be installed and available on the system path.
 
+## Detection CLI
+
+The `detect` command runs object detection on extracted frames. It now supports
+multi-scale execution with per-frame merging. Only "full" passes are currently
+implemented; ``--tiling`` and ``--roi-follow`` are parsed but skipped with a
+warning and have no effect.
+
+- `--multi-scale on|off` – enable the multi-pass workflow.
+- `--scales 1536,1920` – configure base and high-resolution passes.
+- `--tiling far2x2@0.2` – **experimental**, skipped for now.
+- `--roi-follow ball:win=640` – **experimental**, skipped for now.
+
+Example invocation (Docker):
+
+```bash
+docker run --gpus all --rm -v "$(pwd)":/app decoder-detect:latest \
+  detect --frames-dir /app/frames --output-json /app/dets_ms.json \
+         --multi-scale on --scales 1536,1920 \
+         --merge "ball:0.55,person:0.5" \
+         --topk "ball:3,person:8" \
+         --scale-bonus "hi:ball:+0.1"
+```
+
+The implementation uses a clean architecture composed of a pass scheduler,
+execution runner and detection merger. All modules are located under
+`src/detect/`.
+
 When cloning the repository make sure to also fetch the ``ByteTrack``
 submodule:
 

--- a/src/detect/__init__.py
+++ b/src/detect/__init__.py
@@ -1,0 +1,12 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Detection subpackage providing multi-scale utilities."""

--- a/src/detect/merge.py
+++ b/src/detect/merge.py
@@ -1,0 +1,112 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Detection merging utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence
+
+from ..utils.classes import CLASS_NAME_TO_ID
+
+BALL_ID = CLASS_NAME_TO_ID["sports ball"]
+
+
+@dataclass
+class Detection:
+    """Simple representation of a detection."""
+
+    bbox: List[float]
+    score: float
+    class_id: int
+    source: str
+
+
+def _iou(a: Sequence[float], b: Sequence[float]) -> float:
+    ax1, ay1, ax2, ay2 = a
+    bx1, by1, bx2, by2 = b
+    inter_x1 = max(ax1, bx1)
+    inter_y1 = max(ay1, by1)
+    inter_x2 = min(ax2, bx2)
+    inter_y2 = min(ay2, by2)
+    inter_w = max(0.0, inter_x2 - inter_x1)
+    inter_h = max(0.0, inter_y2 - inter_y1)
+    inter = inter_w * inter_h
+    area_a = (ax2 - ax1) * (ay2 - ay1)
+    area_b = (bx2 - bx1) * (by2 - by1)
+    union = area_a + area_b - inter
+    return inter / union if union else 0.0
+
+
+def _wbf(dets: List[Detection], iou_thres: float) -> List[Detection]:
+    clusters: List[List[Detection]] = []
+    for det in dets:
+        for cluster in clusters:
+            if _iou(det.bbox, cluster[0].bbox) >= iou_thres:
+                cluster.append(det)
+                break
+        else:
+            clusters.append([det])
+    fused: List[Detection] = []
+    for cluster in clusters:
+        total = sum(d.score for d in cluster)
+        x1 = sum(d.bbox[0] * d.score for d in cluster) / total
+        y1 = sum(d.bbox[1] * d.score for d in cluster) / total
+        x2 = sum(d.bbox[2] * d.score for d in cluster) / total
+        y2 = sum(d.bbox[3] * d.score for d in cluster) / total
+        score = max(d.score for d in cluster)
+        fused.append(
+            Detection(bbox=[x1, y1, x2, y2], score=score, class_id=cluster[0].class_id, source="wbf")
+        )
+    return fused
+
+
+def _nms(dets: List[Detection], iou_thres: float) -> List[Detection]:
+    dets = sorted(dets, key=lambda d: d.score, reverse=True)
+    kept: List[Detection] = []
+    for det in dets:
+        if all(_iou(det.bbox, k.bbox) < iou_thres for k in kept):
+            kept.append(det)
+    return kept
+
+
+def merge_detections(
+    det_lists: Iterable[List[Detection]],
+    iou: Dict[int, float] | None = None,
+    bonuses: Dict[str, Dict[int, float]] | None = None,
+    topk: Dict[int, int] | None = None,
+) -> List[Detection]:
+    """Merge detections from multiple passes."""
+
+    all_dets: List[Detection] = []
+    for dets in det_lists:
+        for d in dets:
+            bonus = bonuses.get(d.source, {}).get(d.class_id, 0.0) if bonuses else 0.0
+            all_dets.append(
+                Detection(bbox=d.bbox, score=d.score + bonus, class_id=d.class_id, source=d.source)
+            )
+
+    merged: List[Detection] = []
+    by_class: Dict[int, List[Detection]] = {}
+    for d in all_dets:
+        by_class.setdefault(d.class_id, []).append(d)
+    for cid, dets in by_class.items():
+        thr = iou.get(cid, 0.5) if iou else 0.5
+        if cid == BALL_ID:
+            merged_cls = _wbf(dets, thr)
+        else:
+            merged_cls = _nms(dets, thr)
+        merged_cls = sorted(merged_cls, key=lambda d: d.score, reverse=True)
+        if topk and cid in topk:
+            merged_cls = merged_cls[: topk[cid]]
+        merged.extend(merged_cls)
+    return merged

--- a/src/detect/ms_scheduler.py
+++ b/src/detect/ms_scheduler.py
@@ -1,0 +1,71 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Multi-scale scheduler for detection passes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import List, Optional
+
+
+@dataclass
+class PassConfig:
+    """Configuration for a single detection pass."""
+
+    name: str
+    scale: int
+    type: str = "full"
+    grid: Optional[tuple[int, int]] = None
+    overlap: float | None = None
+    roi: Optional[tuple[int, int, int, int]] = None
+
+
+class MSScheduler:
+    """Build a list of detection passes based on CLI options."""
+
+    def __init__(
+        self, scales: List[int], tiling: str | None = None, roi_follow: str | None = None
+    ) -> None:
+        self.scales = scales
+        self.tiling = tiling
+        self.roi_follow = roi_follow
+
+    def build(self, has_homography: bool = False) -> List[PassConfig]:
+        """Return a list of :class:`PassConfig` objects."""
+
+        passes: List[PassConfig] = []
+        if not self.scales:
+            raise ValueError("at least one scale is required")
+        passes.append(PassConfig(name="base", scale=self.scales[0]))
+        if len(self.scales) > 1:
+            passes.append(PassConfig(name="hi", scale=self.scales[1]))
+        if self.tiling and has_homography:
+            grid_part, overlap_part = self.tiling.split("@")
+            match = re.search(r"(\d+)x(\d+)", grid_part)
+            if match:
+                gx, gy = int(match.group(1)), int(match.group(2))
+                overlap = float(overlap_part)
+                passes.append(
+                    PassConfig(
+                        name="tile",
+                        scale=self.scales[0],
+                        type="tile",
+                        grid=(gx, gy),
+                        overlap=overlap,
+                    )
+                )
+        if self.roi_follow:
+            match = re.search(r"win=(\d+)", self.roi_follow)
+            win = int(match.group(1)) if match else self.scales[0]
+            passes.append(PassConfig(name="roi", scale=win, type="roi"))
+        return passes

--- a/src/detect/runner.py
+++ b/src/detect/runner.py
@@ -1,0 +1,65 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Runner executing detection passes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+from .ms_scheduler import PassConfig
+
+
+class DetectionRunner:
+    """Execute detection passes and map boxes to global coordinates."""
+
+    def __init__(self, detect_func: Callable[[List[Path], int], List[List[Dict[str, Any]]]]):
+        self.detect_func = detect_func
+
+    def run(self, frames: List[Path], cfg: PassConfig) -> Dict[Path, List[Dict[str, Any]]]:
+        if cfg.type == "full":
+            outputs = self.detect_func(frames, cfg.scale)
+            return {f: d for f, d in zip(frames, outputs)}
+        if cfg.type == "roi" and cfg.roi is not None:
+            x1, y1, _, _ = cfg.roi
+            outputs = self.detect_func(frames, cfg.scale)
+            adjusted: Dict[Path, List[Dict[str, Any]]] = {}
+            for f, dets in zip(frames, outputs):
+                adj: List[Dict[str, Any]] = []
+                for d in dets:
+                    bx = d["bbox"]
+                    adj_box = [bx[0] + x1, bx[1] + y1, bx[2] + x1, bx[3] + y1]
+                    nd = dict(d)
+                    nd["bbox"] = adj_box
+                    adj.append(nd)
+                adjusted[f] = adj
+            return adjusted
+        if cfg.type == "tile" and cfg.grid is not None:
+            gx, gy = cfg.grid
+            tile_w = cfg.scale // gx
+            tile_h = cfg.scale // gy
+            outputs = self.detect_func(frames, cfg.scale)
+            adjusted: Dict[Path, List[Dict[str, Any]]] = {f: [] for f in frames}
+            for y in range(gy):
+                for x in range(gx):
+                    x_off = x * tile_w
+                    y_off = y * tile_h
+                    for f, dets in zip(frames, outputs):
+                        for d in dets:
+                            bx = d["bbox"]
+                            adj_box = [bx[0] + x_off, bx[1] + y_off, bx[2] + x_off, bx[3] + y_off]
+                            nd = dict(d)
+                            nd["bbox"] = adj_box
+                            adjusted[f].append(nd)
+            return adjusted
+        outputs = self.detect_func(frames, cfg.scale)
+        return {f: d for f, d in zip(frames, outputs)}

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -1,0 +1,34 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`src.detect.merge`."""
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.detect.merge import Detection, merge_detections
+from src.utils.classes import CLASS_NAME_TO_ID
+
+
+def test_wbf_and_topk() -> None:
+    ball_id = CLASS_NAME_TO_ID["sports ball"]
+    d1 = Detection(bbox=[0.0, 0.0, 10.0, 10.0], score=0.9, class_id=ball_id, source="base")
+    d2 = Detection(bbox=[1.0, 1.0, 11.0, 11.0], score=0.8, class_id=ball_id, source="hi")
+    merged = merge_detections(
+        [[d1], [d2]],
+        iou={ball_id: 0.5},
+        bonuses={"hi": {ball_id: 0.1}},
+        topk={ball_id: 1},
+    )
+    assert len(merged) == 1
+    assert merged[0].score > 0.8
+    assert merged[0].bbox[0] > 0.0

--- a/tests/test_ms_framewise_merge.py
+++ b/tests/test_ms_framewise_merge.py
@@ -1,0 +1,42 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Ensure frame-wise merges do not leak detections across frames."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.detect.merge import Detection as MSD, merge_detections
+from src.utils.classes import CLASS_NAME_TO_ID
+
+
+def test_framewise_merge_no_cross_leak() -> None:
+    """Detections from different frames must be merged independently."""
+
+    pid = CLASS_NAME_TO_ID["person"]
+
+    f0_base = [MSD([0, 0, 10, 10], 0.9, pid, "base")]
+    f0_hi = [MSD([1, 1, 11, 11], 0.8, pid, "hi")]
+
+    f1_base = [MSD([100, 100, 110, 110], 0.9, pid, "base")]
+    f1_hi = [MSD([101, 101, 111, 111], 0.8, pid, "hi")]
+
+    m0 = merge_detections([f0_base, f0_hi], iou={pid: 0.5})
+    m1 = merge_detections([f1_base, f1_hi], iou={pid: 0.5})
+
+    assert len(m0) >= 1
+    assert len(m1) >= 1
+    assert m0[0].bbox[0] < 50
+    assert m1[0].bbox[0] > 50

--- a/tests/test_ms_scheduler.py
+++ b/tests/test_ms_scheduler.py
@@ -1,0 +1,26 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`src.detect.ms_scheduler`."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.detect.ms_scheduler import MSScheduler
+
+
+def test_build_passes_all() -> None:
+    sched = MSScheduler(scales=[640, 1280], tiling="far2x2@0.1", roi_follow="ball:win=320")
+    passes = sched.build(has_homography=True)
+    names = [p.name for p in passes]
+    assert names == ["base", "hi", "tile", "roi"]

--- a/tests/test_ms_utils.py
+++ b/tests/test_ms_utils.py
@@ -1,0 +1,31 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for small helpers used in multi-scale detection."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.detect_objects import _is_box_detection
+
+
+def test_is_box_detection() -> None:
+    """Validate that only dicts with bbox and score are considered boxes."""
+
+    assert _is_box_detection({"bbox": [0, 0, 1, 1], "score": 0.9, "class": 0})
+    assert not _is_box_detection({"polygon": [[0, 0], [1, 0], [1, 1], [0, 1]], "score": 1.0})
+    assert not _is_box_detection({"bbox": [0, 0, 1, 1]})
+    assert not _is_box_detection({"score": 0.5})
+    assert not _is_box_detection(None)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,34 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`src.detect.runner`."""
+
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from src.detect.ms_scheduler import PassConfig
+from src.detect.runner import DetectionRunner
+
+
+def _dummy(frames: list[Path], scale: int):
+    return [[{"bbox": [1.0, 2.0, 3.0, 4.0], "score": 0.9, "class_id": 0}] for _ in frames]
+
+
+def test_roi_offsets(tmp_path: Path) -> None:
+    frame = tmp_path / "f.png"
+    frame.touch()
+    runner = DetectionRunner(_dummy)
+    cfg = PassConfig(name="roi", scale=100, type="roi", roi=(10, 20, 30, 40))
+    out = runner.run([frame], cfg)
+    det = out[frame][0]
+    assert det["bbox"] == [11.0, 22.0, 13.0, 24.0]


### PR DESCRIPTION
## Summary
- run real multi-scale detection passes and merge results per frame
- support class-specific merge/top-k and scale bonuses in CLI
- document multi-scale usage and warn for unsupported tiling/ROI passes
- add unit test ensuring framewise merge independence
- auto-load default court.json for multi-scale runs and support legacy NMS arg names
- ensure detect_two_pass returns an empty list when no frames are found
- filter out polygon-only detections and union actual frame keys during merge
- disable court detection in internal multi-scale passes to prevent KeyErrors
- add unit test for box-detection helper

## Testing
- `pytest -vv`
- `docker run --gpus all --rm -v "$(pwd)":/app decoder-detect:latest detect --frames-dir /app/frames --output-json /app/dets_single.json` *(fails: command not found: docker)*
- `docker run --gpus all --rm -v "$(pwd)":/app decoder-detect:latest detect --frames-dir /app/frames --output-json /app/dets_ms.json --multi-scale on --scales 1536,1920 --merge "ball:0.55,person:0.5" --topk "ball:3,person:8" --scale-bonus "hi:ball:+0.1"` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68ac129dfdec832f85a1bc5011728f94