### PR TITLE
feat(track): add color descriptor and adaptive threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,12 +257,14 @@ docker run --gpus all --rm -v "$(pwd)":/app decoder-track:latest \
         --fps 30 --min-score 0.28 \
         --pre-nms-iou 0.6 --pre-min-area-q 0.15 --pre-topk 3 --pre-court-gate \
         --p-match-thresh 0.55 --p-track-buffer 160 --reid-reuse-window 150 \
-        --b-match-thresh 0.55 --b-track-buffer 150 \
+        --b-match-thresh 0.55 --b-track-buffer 150 --color-sim-w 0.10 \
         --stitch --stitch-iou 0.55 --stitch-gap 12 \
         --smooth ema --smooth-alpha 0.3 \
         --assoc-plane court --assoc-w-iou 0.4 --assoc-w-plane 0.6 \
         --assoc-plane-thresh 0.25
 ```
+Frames in `--frames-dir` may be named `000001.jpg|png` or `frame_000001.jpg|png`; PNGs with alpha are converted to RGB automatically.
+
 > `pre-court-gate` works only with a real court polygon. If `court.json` is a full-frame placeholder, the gate has no effect—either disable it (`--no-pre-court-gate`) or run `decoder-court` with weights to obtain real geometry.
 
 Association tuning:
@@ -719,6 +721,7 @@ This prints the number of invalid bounding boxes and low-confidence detections.
   | `--min-score` | Detection score threshold | `0.3` |
   | `--fps` | Video frame rate | `30` |
   | `--reid-reuse-window` | Frames to keep IDs for reuse | `125` |
+  | `--color-sim-w` | Weight for colour similarity in ID reuse | `0.0` |
   | `--pre-nms-iou` | Greedy NMS IoU for persons | `0.0` |
   | `--pre-min-area-q` | Quantile filter for small boxes | `0.0` |
   | `--pre-topk` | Keep top-K persons per frame | `0` |

--- a/src/detect_objects.py
+++ b/src/detect_objects.py
@@ -673,6 +673,12 @@ def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
         default=0.25,
         help="Max allowed normalized plane distance for a match (0..1)",
     )
+    tr.add_argument(
+        "--color-sim-w",
+        type=float,
+        default=0.0,
+        help="Weight for colour similarity term in ID reuse",
+    )
     # Person tracker params
     tr.add_argument(
         "--p-track-thresh",
@@ -1946,6 +1952,7 @@ def main(argv: Iterable[str] | None = None) -> None:
                 args.appearance_refine,
                 args.appearance_lambda,
                 args.frames_dir,
+                args.color_sim_w,
             )
         except Exception as exc:  # pragma: no cover - top level
             logger.exception("Tracking failed")

--- a/tests/test_color_descriptor.py
+++ b/tests/test_color_descriptor.py
@@ -1,0 +1,64 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for HSV colour descriptor utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import types
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+loguru_mod = types.ModuleType("loguru")
+loguru_mod.logger = types.SimpleNamespace(remove=lambda *a, **k: None, add=lambda *a, **k: None)
+sys.modules.setdefault("loguru", loguru_mod)
+
+torch_mod = types.ModuleType("torch")
+torch_mod.cuda = types.SimpleNamespace(is_available=lambda: False)
+sys.modules.setdefault("torch", torch_mod)
+
+PIL = pytest.importorskip("PIL")
+from PIL import Image
+
+from src.track_objects import _hsv_hist, _reuse_id
+
+
+def test_hsv_hist_top_half() -> None:
+    img = Image.new("RGB", (10, 10), (0, 0, 255))
+    for y in range(5):
+        for x in range(10):
+            img.putpixel((x, y), (255, 0, 0))
+    hist = _hsv_hist(img, [0, 0, 10, 10])
+    assert abs(sum(hist) - 1.0) < 1e-6
+    red_bin = sum(hist[:64])
+    assert red_bin > 0.8
+
+
+def test_reuse_id_color_weight() -> None:
+    hist1 = [1.0] + [0.0] * 511
+    cache = [{"id": 1, "bbox": [0, 0, 10, 10], "frame": 0, "hist": hist1}]
+    hist2 = hist1.copy()
+    assert _reuse_id(cache, [0, 0, 10, 10], hist2, 1, 10, 0.5) == 1
+    cache = [{"id": 1, "bbox": [0, 0, 10, 10], "frame": 0, "hist": hist1}]
+    hist3 = [0.0] * 512
+    hist3[100] = 1.0
+    assert _reuse_id(cache, [0, 0, 10, 10], hist3, 1, 10, 0.5) is None
+
+
+def test_hsv_hist_handles_rgba() -> None:
+    img = Image.new("RGBA", (8, 8), (0, 255, 0, 128))
+    img2 = img.convert("RGB")
+    hist = _hsv_hist(img2, [0, 0, 8, 8])
+    assert abs(sum(hist) - 1.0) < 1e-6

--- a/tests/test_frame_resolve.py
+++ b/tests/test_frame_resolve.py
@@ -1,0 +1,42 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for frame path resolution utility."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+loguru_mod = types.ModuleType("loguru")
+loguru_mod.logger = types.SimpleNamespace(remove=lambda *a, **k: None, add=lambda *a, **k: None)
+sys.modules.setdefault("loguru", loguru_mod)
+
+from src.track_objects import _resolve_frame_path
+
+
+def test_resolve_frame_path_supports_multiple_patterns(tmp_path: Path) -> None:
+    # create frame_000001.png
+    p = tmp_path / "frame_000001.png"
+    p.write_bytes(b"\x89PNG\r\n\x1a\n")
+    got = _resolve_frame_path(tmp_path, 1)
+    assert got is not None and got.name == "frame_000001.png"
+
+    # create 000001.jpg and check priority (either is acceptable)
+    (tmp_path / "000001.jpg").write_bytes(b"\xff\xd8\xff")
+    got2 = _resolve_frame_path(tmp_path, 1)
+    assert got2 is not None
+    assert got2.name in {"000001.jpg", "frame_000001.png"}


### PR DESCRIPTION
## Summary
- add frame name resolver supporting `000001.*` and `frame_000001.*`
- convert RGBA crops to RGB and raise ID reuse threshold to 0.45
- document color-sim usage and frame naming patterns
- fix half-court gate unpacking for active track triples and initialise court dimensions safely

## Testing
- `pytest -q`
- `docker run --gpus all --rm -v "$(pwd)":/app decoder-track:latest track --detections-json /app/detections.json --output-json /app/tracks.json --frames-dir /app/frames --fps 30 --min-score 0.28 --pre-nms-iou 0.6 --pre-min-area-q 0.15 --pre-topk 3 --pre-court-gate --p-match-thresh 0.55 --p-track-buffer 160 --reid-reuse-window 150 --b-match-thresh 0.55 --b-track-buffer 150 --color-sim-w 0.10 --stitch --stitch-iou 0.55 --stitch-gap 12 --smooth ema --smooth-alpha 0.3 --assoc-plane court --assoc-w-iou 0.4 --assoc-w-plane 0.6 --assoc-plane-thresh 0.25` *(fails: `bash: command not found: docker`)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3ebc48a4832fa168ae2138c4b42e