### PR TITLE
Parameterize court detector builder and guard checkpoint loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1014,5 +1014,28 @@ ffmpeg with libx264.
 
 # 5) sanity metrics
 docker run --rm -v "$(pwd)":/app decoder-track:latest \
-  python tools/verify_tennis_defaults.py --tracks-json /app/tracks.json
+python tools/verify_tennis_defaults.py --tracks-json /app/tracks.json
+```
+### Model weights (TCD, 64-channel)
+
+* File: `weights/tcd.pth` (width check):
+
+```bash
+python - <<'PY'
+import torch; sd=torch.load('weights/tcd.pth','cpu'); sd=sd.get('state_dict',sd) if isinstance(sd,dict) else sd
+print('base_channels =', sd['conv1.block.0.weight'].shape[0])  # should print 64
+PY
+```
+
+* The loader infers `base_channels` from the checkpoint and builds the matching model.
+* Sample execution:
+
+```bash
+docker run --rm -v "$(pwd)":/app decoder-court:latest \
+  --frames-dir  /app/frames \
+  --output-json /app/court.json \
+  --device cpu \
+  --weights /app/weights/tcd.pth \
+  --sample-rate 3 \
+  --min-score 0.25
 ```

--- a/services/court_detector/__init__.py
+++ b/services/court_detector/__init__.py
@@ -11,3 +11,6 @@
 # limitations under the License.
 """Tennis court detector service package."""
 
+from .tcd import build_tcd_model
+
+__all__ = ["build_tcd_model"]


### PR DESCRIPTION
## Summary
- infer `base_channels` from checkpoints and drop mismatched keys before loading
- add minimal `services.court_detector.tcd` builder accepting `base_channels` and fix conv layer names to match checkpoint keys
- document TCD weight verification and sample invocation
- normalize court detector logging and external builder type hints

## Testing
- `ruff check --fix services/court_detector/tcd.py`
- `black services/court_detector/tcd.py`
- `pytest`
- `docker run --rm -v "$(pwd)":/app decoder-court:latest --frames-dir /app/frames --output-json /app/court.json --device cpu --weights /app/weights/tcd.pth --sample-rate 3 --min-score 0.25` *(fails: command not found: docker)*
- `jq '[ .[] | select(.placeholder==false) ] | length' court.json` *(fails: Could not open file court.json: No such file or directory)*
- `jq -r '.[0] | {frame, poly_len:(.polygon|length), has_lines:(.lines|length>0)}' court.json` *(fails: Could not open file court.json: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8e9c11f0832fbf0e3361c8f821d3