### PR TITLE
feat: enable CUDA builds for court detector image

### DIFF
--- a/Dockerfile.court
+++ b/Dockerfile.court
@@ -8,10 +8,23 @@ LABEL org.opencontainers.image.source="https://github.com/boog9/decoder-poc" \
 WORKDIR /app
 ENV PYTHONPATH=/app
 
+# === Select PyTorch variant ===
+# TORCH_CHANNEL: "cpu" (default) or "cu121" for CUDA 12.1
+ARG TORCH_CHANNEL=cpu
+ENV TORCH_CHANNEL=${TORCH_CHANNEL}
+
 # Install base and court detector dependencies
 COPY services/court_detector/requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir pillow loguru \
-    && pip install --no-cache-dir -r /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+ && pip install --no-cache-dir pillow loguru opencv-python-headless numpy \
+ && if [ "$TORCH_CHANNEL" = "cu121" ]; then \
+      pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cu121 \
+        torch==2.4.0 torchvision==0.19.0 torchaudio==2.4.0 ; \
+    else \
+      pip install --no-cache-dir \
+        torch==2.4.0 torchvision==0.19.0 torchaudio==2.4.0 ; \
+    fi \
+ && pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Copy source and create weights directory
 COPY services/ /app/services/

--- a/README.md
+++ b/README.md
@@ -1033,6 +1033,18 @@ docker run -i --rm -v "$(pwd)":/app --entrypoint python decoder-court:latest \
   tools/check_tcd_weights.py
 ```
 
+### Build images
+
+```bash
+# CPU (default)
+DOCKER_BUILDKIT=1 docker build -f Dockerfile.court -t decoder-court:latest \
+  --build-arg TORCH_CHANNEL=cpu .
+
+# CUDA 12.1
+DOCKER_BUILDKIT=1 docker build -f Dockerfile.court -t decoder-court:cuda \
+  --build-arg TORCH_CHANNEL=cu121 .
+```
+
 ### Run inference
 
 ```bash
@@ -1040,6 +1052,17 @@ docker run --rm -v "$(pwd)":/app decoder-court:latest \
   --frames-dir /app/frames \
   --output-json /app/court.json \
   --device cpu \
+  --weights /app/weights/tcd.pth \
+  --min-score 0.55 \
+  --sample-rate 4
+```
+
+GPU:
+```bash
+docker run --rm --gpus all -v "$(pwd)":/app decoder-court:cuda \
+  --frames-dir /app/frames \
+  --output-json /app/court.json \
+  --device cuda \
   --weights /app/weights/tcd.pth \
   --min-score 0.55 \
   --sample-rate 4

--- a/services/court_detector/requirements.txt
+++ b/services/court_detector/requirements.txt
@@ -1,7 +1,5 @@
 Pillow
 loguru>=0.7.0
-torch
-torchvision
 numpy
 opencv-python-headless
 shapely

--- a/src/court_calib.py
+++ b/src/court_calib.py
@@ -133,6 +133,12 @@ def main() -> None:
     parser.add_argument("--smooth-alpha", type=float, default=0.3)
     args = parser.parse_args()
 
+    # Auto-fallback: switch to CPU if CUDA is unavailable
+    import torch, sys
+    if args.device == "cuda" and not torch.cuda.is_available():
+        print("| WARN | CUDA requested but not available; falling back to CPU.", file=sys.stderr)
+        args.device = "cpu"
+
     frames_dir = Path(args.frames_dir)
     out_path = Path(args.output_json)
 

--- a/tests/test_tcd_preprocess.py
+++ b/tests/test_tcd_preprocess.py
@@ -24,5 +24,5 @@ def test_preprocess_shape_and_range() -> None:
     img = np.zeros((100, 200, 3), dtype=np.uint8)
     tensor = preprocess_to_640x360(img)
     assert tensor.shape == (1, 3, 360, 640)
-    assert tensor.dtype.name == "float32"
+    assert str(tensor.dtype) == "torch.float32"
     assert tensor.min().item() == 0.0 and tensor.max().item() == 0.0


### PR DESCRIPTION
## Summary
- add optional CUDA 12.1 build arg to `decoder-court` image
- remove torch dependencies from court detector requirements
- auto-fallback to CPU when CUDA unavailable
- document CPU/GPU build and run instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acb70d6e7c832f997302132fe54ec2