### PR TITLE
Improve court scoring and CUDA image docs

### DIFF
--- a/tools/check_tcd_weights.py
+++ b/tools/check_tcd_weights.py
@@ -25,7 +25,10 @@ def main() -> None:  # pragma: no cover - used in Docker verification
     module = importlib.import_module("services.court_detector.tcd")
     model_static = getattr(module, "TennisCourtDetector")
     model_dynamic = getattr(module, "TennisCourtDetectorFromSD", None)
-    sd_raw = torch.load("weights/tcd.pth", map_location="cpu")
+    try:
+        sd_raw = torch.load("weights/tcd.pth", map_location="cpu", weights_only=True)
+    except TypeError:
+        sd_raw = torch.load("weights/tcd.pth", map_location="cpu")
     sd = sd_raw.get("state_dict", sd_raw) if isinstance(sd_raw, dict) else sd_raw
     if model_dynamic is not None:
         model = model_dynamic(sd)


### PR DESCRIPTION
## Summary
- Normalize heatmap activations and add configurable scoring to `court_calib`
- Safely load weights in `court_calib` and `tools/check_tcd_weights`
- Document building local `decoder-court:cuda` image and new parameters
- Add `--fallback` option to control polygons for low-confidence frames and remove deprecated placeholder flag
- Record polygon source (`detect`, `last`, `full`) in `court.json` for easier debugging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acbb53aefc832f8b93f5c7c96dd79e