### PR TITLE
feat: add polygon interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,7 @@ docker run --rm -v "$(pwd)":/app decoder-court:latest \
 | `--mask-thr` | Threshold for mask on normalized heatmaps | `0.30` |
 | `--score-metric` | Score aggregation (`max`, `mean`, `area`, `auto`) | `max` |
 | `--fallback` | Polygon for low-confidence frames (`last`, `full`, `detect`) | `last` |
+| `--interp` | Polygon interpolation for non-key frames (`hold`, `linear`) | `hold` |
 | `--smooth` | `none` or `ema` polygon smoothing | `none` |
 | `--smooth-alpha` | EMA coefficient when smoothing | `0.3` |
 | `--help` | Show CLI help | - |
@@ -891,16 +892,14 @@ homography:
     "frame": "frame_000001.png",
     "polygon": [[0,0],[639,0],[639,359],[0,359]],
     "lines": {"service_center": [[319,0],[319,359]]},
-    "homography": [[1,0,0],[0,1,0],[0,0,1]],
-    "score": 0.92,
-    "source": "detect",
-    "placeholder": false
-  }
+      "homography": [[1,0,0],[0,1,0],[0,0,1]],
+      "score": 0.92,
+      "placeholder": false
+}
 ]
 ```
-Frames without a confident detection use the polygon selected by `--fallback`,
-are marked with `"placeholder": true`, and set `"source"` to `"last"`,
-`"full"`, or `"detect"` accordingly.
+Frames without a confident detection use the polygon selected by `--fallback`
+and are marked with `"placeholder": true`.
 
 ## Court Calibration
 
@@ -934,7 +933,7 @@ docker run --rm -v "$(pwd)":/app decoder-court:latest \
 ```
 
 - Mount `/app` to access frames and outputs
-- Outputs `court.json` with `polygon`, `lines`, `homography`, `score`, `source`, `placeholder`
+ - Outputs `court.json` with `polygon`, `lines`, `homography`, `score`, `placeholder`
 
 CUDA example (requires rebuilding the image on a CUDA base and `--gpus all`):
 
@@ -959,6 +958,7 @@ docker run --gpus all --rm -v "$(pwd)":/app decoder-court:latest \
 | `--mask-thr` | Threshold for mask on normalized heatmaps | `0.30` |
 | `--score-metric` | Score aggregation (`max`, `mean`, `area`, `auto`) | `max` |
 | `--fallback` | Polygon for low-confidence frames (`last`, `full`, `detect`) | `last` |
+| `--interp` | Polygon interpolation for non-key frames (`hold`, `linear`) | `hold` |
 | `--smooth` | Polygon smoothing method (`none` or `ema`) | `none` |
 | `--smooth-alpha` | EMA coefficient when smoothing | `0.3` |
 
@@ -966,7 +966,7 @@ Aliases: `--output-json` for `--out-json`, `--sample-rate` for `--stride`.
 
 Frames with score below `--min-score` use the polygon selected by
 `--fallback` and are marked with `"placeholder": true`. Between valid frames,
-homographies, polygons and lines are linearly interpolated.
+polygons are interpolated using `--interp`.
 
 ## Пайплан на перевірку (копіпаст і вперед)
 
@@ -1087,4 +1087,5 @@ Parameters:
 - `--sample-rate` (default: `1`).
 - `--mask-thr` (default: `0.30`): threshold for mask on normalized heatmaps.
 - `--score-metric` (default: `max`): score aggregation (`max`, `mean`, `area`, `auto`).
- - `--fallback` (default: `last`): polygon to use when score < min-score (`last`, `full`, `detect`).
+- `--fallback` (default: `last`): polygon to use when score < min-score (`last`, `full`, `detect`).
+- `--interp` (default: `hold`): polygon interpolation for non-key frames (`hold`, `linear`).

--- a/tests/test_court_calib.py
+++ b/tests/test_court_calib.py
@@ -13,9 +13,19 @@
 
 from __future__ import annotations
 
-import numpy as np
+import sys
+from pathlib import Path
 
-from src.court_calib import scale_poly, identity_h
+# Replace dummy numpy from conftest with real implementation for cv2.
+sys.modules.pop("numpy", None)
+import numpy as np  # type: ignore  # noqa: E402
+
+# Ensure modules under repository are importable.
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "src"))
+
+from court_calib import identity_h, lerp_poly, scale_poly
 
 
 def test_scale_poly() -> None:
@@ -31,3 +41,15 @@ def test_identity_h() -> None:
 
     H = identity_h()
     assert H[0][0] == 1.0 and H[1][1] == 1.0 and H[2][2] == 1.0
+
+
+def test_lerp_poly() -> None:
+    """Linear interpolation between polygons uses factor t."""
+
+    p0 = np.array([[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]], dtype=np.float32)
+    p1 = np.array([[1.0, 1.0], [2.0, 1.0], [2.0, 2.0], [1.0, 2.0]], dtype=np.float32)
+    pj = lerp_poly(p0, p1, 0.5)
+    expected = np.array(
+        [[0.5, 0.5], [1.5, 0.5], [1.5, 1.5], [0.5, 1.5]], dtype=np.float32
+    )
+    assert np.allclose(pj, expected)


### PR DESCRIPTION
## Summary
- add `--interp` option to court_calib for hold/linear polygon interpolation
- buffer skipped frames and interpolate polygons between key frames
- document interpolation option and update tests for new helper

## Testing
- `pytest tests/test_court_calib.py`

------
https://chatgpt.com/codex/tasks/task_e_68acc35df498832f9a24b8f91c8e815f