### PR TITLE
Add Tennis Court Detector model and CLI with heatmap overlay

### DIFF
--- a/Dockerfile.court
+++ b/Dockerfile.court
@@ -13,18 +13,22 @@ ENV PYTHONPATH=/app
 ARG TORCH_CHANNEL=cpu
 ENV TORCH_CHANNEL=${TORCH_CHANNEL}
 
+# Additional index for PyTorch wheels
+ARG PIP_EXTRA_INDEX_URL=
+
 # Install base and court detector dependencies
 COPY services/court_detector/requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir --upgrade pip \
- && pip install --no-cache-dir pillow loguru opencv-python-headless numpy \
- && if [ "$TORCH_CHANNEL" = "cu121" ]; then \
+RUN pip install --no-cache-dir --upgrade pip && \
+    if [ "$TORCH_CHANNEL" = "cu121" ]; then \
       pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cu121 \
-        torch==2.4.0 torchvision==0.19.0 torchaudio==2.4.0 ; \
+        torch==2.2.2+cu121 torchvision==0.17.2+cu121 ; \
     else \
-      pip install --no-cache-dir \
-        torch==2.4.0 torchvision==0.19.0 torchaudio==2.4.0 ; \
-    fi \
- && pip install --no-cache-dir -r /tmp/requirements.txt
+      pip install --no-cache-dir torch==2.2.2 torchvision==0.17.2 ; \
+    fi && \
+    pip install --no-cache-dir \
+      numpy==1.26.4 scipy==1.10.1 scikit-image==0.21.0 \
+      opencv-python-headless==4.8.1.78 pillow loguru && \
+    pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Copy source and create weights directory
 COPY services/ /app/services/
@@ -33,4 +37,4 @@ COPY tools/ /app/tools/
 RUN mkdir -p /app/weights
 
 # Default entry point runs court calibration
-ENTRYPOINT ["python", "-m", "src.court_calib"]
+ENTRYPOINT ["python", "-m", "services.court_detector.run_court"]

--- a/services/court_detector/postproc.py
+++ b/services/court_detector/postproc.py
@@ -1,0 +1,64 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Post-processing utilities for tennis court keypoints."""
+
+from __future__ import annotations
+
+import cv2
+import numpy as np
+from typing import Tuple, Optional
+
+
+def heat_to_peak_xy(
+    heat_uint8: np.ndarray, low_thresh: int = 170, max_radius: int = 25
+) -> Tuple[Optional[int], Optional[int]]:
+    """Return the (x, y) coordinate of the dominant peak in a heatmap.
+
+    Args:
+        heat_uint8: Single-channel heatmap as ``uint8``.
+        low_thresh: Values below this threshold are set to zero before peak
+            extraction.
+        max_radius: Unused placeholder for possible local refinement.
+
+    Returns:
+        ``(x, y)`` coordinate of the peak or ``(None, None)`` if no peak is
+        detected.
+    """
+
+    _, thr = cv2.threshold(heat_uint8, low_thresh, 255, cv2.THRESH_TOZERO)
+    _min_val, max_val, _min_loc, max_loc = cv2.minMaxLoc(thr)
+    if max_val <= 0:
+        return (None, None)
+    return (max_loc[0], max_loc[1])
+
+
+def refine_kps_if_needed(
+    orig_bgr: np.ndarray,
+    x: Optional[int],
+    y: Optional[int],
+    disable_idx: Tuple[int, int, int] = (8, 12, 9),
+    k_idx: Optional[int] = None,
+) -> Tuple[Optional[int], Optional[int]]:
+    """Optional keypoint refinement hook.
+
+    Current implementation is a stub that returns the input coordinates unless
+    the keypoint index is disabled.
+    """
+
+    if x is None or y is None:
+        return (x, y)
+    if k_idx in disable_idx:
+        return (x, y)
+    return (x, y)
+
+
+__all__ = ["heat_to_peak_xy", "refine_kps_if_needed"]

--- a/services/court_detector/run_court.py
+++ b/services/court_detector/run_court.py
@@ -1,0 +1,255 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CLI for running the Tennis Court Detector."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+from typing import List, Tuple
+
+import cv2
+import numpy as np
+import torch
+
+from .tcd_model import BallTrackerNet
+from .utils_weights import load_tcd_state_dict
+from .postproc import heat_to_peak_xy, refine_kps_if_needed
+
+
+def preprocess_bgr(img: np.ndarray, device: torch.device) -> torch.Tensor:
+    """Resize BGR image to 640×360 and convert to ``[0, 1]`` RGB tensor."""
+
+    rgb = cv2.cvtColor(cv2.resize(img, (640, 360)), cv2.COLOR_BGR2RGB).astype(
+        np.float32
+    )
+    x = torch.from_numpy(rgb.transpose(2, 0, 1)).unsqueeze(0).to(device)
+    return x / 255.0
+
+
+def estimate_homography_and_polygon(
+    points_xy: List[Tuple[float | None, float | None]], refer_kps: np.ndarray
+) -> Tuple[None, None]:
+    """Placeholder for homography estimation.
+
+    Returns ``(None, None)`` until proper correspondence is implemented.
+    """
+
+    pts = np.array([p for p in points_xy if p[0] is not None], dtype=np.float32)
+    if pts.shape[0] < 6:
+        return None, None
+    return None, None
+
+
+def polygon_from_projected_kps(projected_pts: np.ndarray) -> None:
+    """Placeholder for polygon construction from projected keypoints."""
+
+    return None
+
+
+def save_heat_overlay(img_bgr: np.ndarray, pred15: np.ndarray, out_path: str) -> None:
+    """Save heatmap overlay for debugging."""
+
+    hm = np.maximum(0, pred15).sum(0)
+    mx = float(hm.max())
+    if mx <= 0:
+        hm = np.zeros_like(hm, dtype=np.uint8)
+    else:
+        hm = (255 * (hm / mx)).astype(np.uint8)
+    hm = cv2.applyColorMap(
+        cv2.resize(hm, (img_bgr.shape[1], img_bgr.shape[0])), cv2.COLORMAP_JET
+    )
+    over = (0.6 * img_bgr + 0.4 * hm).astype(np.uint8)
+    cv2.imwrite(out_path, over)
+
+
+def process_frames(
+    frames_dir: str,
+    weights_path: str,
+    out_json: str,
+    sample_rate: int = 1,
+    low_thresh: int = 170,
+    dump_heatmaps: bool = False,
+    device: str = "cpu",
+    kp_json_path: str | None = None,
+) -> None:
+    """Run court detection on a directory of frames."""
+
+    device_str = device
+    if device_str == "cuda" and not torch.cuda.is_available():
+        device_str = "cpu"
+    dev = torch.device(device_str)
+
+    model = BallTrackerNet(out_channels=15)
+    sd = load_tcd_state_dict(weights_path)
+    model.load_state_dict(sd, strict=True)
+    model.eval().to(dev)
+
+    patterns = [
+        "frame_*.png",
+        "frame_*.jpg",
+        "frame_*.jpeg",
+        "*.png",
+        "*.jpg",
+        "*.jpeg",
+    ]
+    frames: List[str] = []
+    for pat in patterns:
+        frames.extend(glob.glob(os.path.join(frames_dir, pat)))
+
+    def _natkey(p: str) -> List[int | str]:
+        """Key for natural sorting based on numeric suffix."""
+
+        b = os.path.basename(p)
+        return [int(t) if t.isdigit() else t.lower() for t in re.split(r"(\d+)", b)]
+
+    frames = sorted(frames, key=_natkey)
+    if not frames:
+        print(f"[court][ERROR] No frames found in {frames_dir} (png/jpg)")
+        raise SystemExit(2)
+    out = []
+    all_kps: List[dict] = []
+
+    for i, fp in enumerate(frames):
+        if (i % sample_rate) != 0:
+            out.append(
+                {
+                    "frame": os.path.basename(fp),
+                    "polygon": [],
+                    "lines": {},
+                    "homography": [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                    "score": 0.0,
+                    "placeholder": True,
+                }
+            )
+            continue
+
+        img = cv2.imread(fp, cv2.IMREAD_COLOR)
+        if img is None:
+            out.append(
+                {
+                    "frame": os.path.basename(fp),
+                    "polygon": [],
+                    "lines": {},
+                    "homography": [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                    "score": 0.0,
+                    "placeholder": True,
+                }
+            )
+            continue
+
+        x = preprocess_bgr(img, dev)
+        with torch.inference_mode():
+            hm = model(x)[0]
+            pred = torch.sigmoid(hm).cpu().numpy()
+
+        if dump_heatmaps:
+            save_heat_overlay(img, pred, fp + ".heat.png")
+
+        points: List[Tuple[int | None, int | None]] = []
+        for k in range(14):
+            heat = (pred[k] * 255.0).astype(np.uint8)
+            xk, yk = heat_to_peak_xy(heat, low_thresh=low_thresh, max_radius=25)
+            xk, yk = refine_kps_if_needed(img, xk, yk, k_idx=k)
+            points.append((xk, yk))
+
+        H, poly = None, None
+        if H is None or poly is None:
+            out.append(
+                {
+                    "frame": os.path.basename(fp),
+                    "polygon": [],
+                    "lines": {},
+                    "homography": [[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+                    "score": 0.0,
+                    "placeholder": True,
+                }
+            )
+        else:
+            out.append(
+                {
+                    "frame": os.path.basename(fp),
+                    "polygon": poly,
+                    "lines": {},
+                    "homography": H.tolist(),
+                    "score": 1.0,
+                    "placeholder": False,
+                }
+            )
+        all_kps.append({"frame": os.path.basename(fp), "kps": points})
+
+    with open(out_json, "w", encoding="utf-8") as f:
+        json.dump(out, f, indent=2)
+    if kp_json_path:
+        with open(kp_json_path, "w", encoding="utf-8") as f:
+            json.dump(all_kps, f, indent=2)
+    total = len(out)
+    placeholders = sum(1 for it in out if it.get("placeholder", True))
+    print(f"[court] frames={total} placeholders={placeholders} valid={total - placeholders}")
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    """Construct the command line parser."""
+
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--frames-dir", required=True, help="Directory with input frames")
+    p.add_argument("--output-json", required=True, help="Path for output JSON")
+    p.add_argument("--out-json", dest="output_json", help=argparse.SUPPRESS)
+    p.add_argument(
+        "--weights", default="/app/weights/tcd.pth", help="Path to TCD weights"
+    )
+    p.add_argument("--device", default="cpu", help="Execution device: cpu or cuda")
+    p.add_argument("--sample-rate", type=int, default=1, help="Process every Nth frame")
+    p.add_argument("--stride", dest="sample_rate", type=int, help=argparse.SUPPRESS)
+    p.add_argument("--min-score", type=float, default=0.55, help="Reserved for future use")
+    p.add_argument(
+        "--mask-thr",
+        type=float,
+        default=0.67,
+        help="Normalized threshold on sigmoid heatmaps [0..1]; 0.67 ~= 170/255",
+    )
+    p.add_argument("--score-metric", default="max", help="Reserved for future use")
+    p.add_argument(
+        "--dump-heatmaps",
+        action="store_true",
+        help="Write heatmap overlays next to frames",
+    )
+    p.add_argument(
+        "--dump-kps-json",
+        dest="kp_json_path",
+        help="Optional path to write raw keypoints per frame",
+    )
+    return p
+
+
+def main(args: List[str] | None = None) -> None:
+    """Entry point for the CLI."""
+
+    parser = build_argparser()
+    ns = parser.parse_args(args)  # aliases already mapped via dest
+    process_frames(
+        frames_dir=ns.frames_dir,
+        weights_path=ns.weights,
+        out_json=ns.output_json,
+        sample_rate=ns.sample_rate,
+        low_thresh=int(ns.mask_thr * 255),
+        dump_heatmaps=ns.dump_heatmaps,
+        device=ns.device,
+        kp_json_path=ns.kp_json_path,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/services/court_detector/tcd_model.py
+++ b/services/court_detector/tcd_model.py
@@ -1,0 +1,115 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Torch implementation of the official TCD network architecture.
+
+This module mirrors the reference model released with the Tennis Court Detector
+(TCD).  Layer names are kept intact so that the pretrained checkpoint from the
+original project can be loaded with ``strict=True``.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+
+
+class ConvBlock(nn.Module):
+    """Convolution → ReLU → BatchNorm block."""
+
+    def __init__(
+        self,
+        cin: int,
+        cout: int,
+        k: int = 3,
+        pad: int = 1,
+        stride: int = 1,
+        bias: bool = True,
+    ) -> None:
+        super().__init__()
+        self.block = nn.Sequential(
+            nn.Conv2d(cin, cout, k, stride=stride, padding=pad, bias=bias),
+            nn.ReLU(),
+            nn.BatchNorm2d(cout),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass through the block."""
+
+        return self.block(x)
+
+
+class BallTrackerNet(nn.Module):
+    """Full TCD network used for court detection.
+
+    Args:
+        out_channels: Number of output channels. The official model exposes
+            15 keypoint heatmaps.
+    """
+
+    def __init__(self, out_channels: int = 15) -> None:
+        super().__init__()
+        self.conv1 = ConvBlock(3, 64)
+        self.conv2 = ConvBlock(64, 64)
+        self.pool1 = nn.MaxPool2d(2, 2)
+        self.conv3 = ConvBlock(64, 128)
+        self.conv4 = ConvBlock(128, 128)
+        self.pool2 = nn.MaxPool2d(2, 2)
+        self.conv5 = ConvBlock(128, 256)
+        self.conv6 = ConvBlock(256, 256)
+        self.conv7 = ConvBlock(256, 256)
+        self.pool3 = nn.MaxPool2d(2, 2)
+        self.conv8 = ConvBlock(256, 512)
+        self.conv9 = ConvBlock(512, 512)
+        self.conv10 = ConvBlock(512, 512)
+        self.ups1 = nn.Upsample(scale_factor=2)
+        self.conv11 = ConvBlock(512, 256)
+        self.conv12 = ConvBlock(256, 256)
+        self.conv13 = ConvBlock(256, 256)
+        self.ups2 = nn.Upsample(scale_factor=2)
+        self.conv14 = ConvBlock(256, 128)
+        self.conv15 = ConvBlock(128, 128)
+        self.ups3 = nn.Upsample(scale_factor=2)
+        self.conv16 = ConvBlock(128, 64)
+        self.conv17 = ConvBlock(64, 64)
+        self.conv18 = ConvBlock(64, out_channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Forward pass producing ``out_channels`` heatmaps."""
+
+        x = self.conv1(x)
+        x = self.conv2(x)
+        x = self.pool1(x)
+        x = self.conv3(x)
+        x = self.conv4(x)
+        x = self.pool2(x)
+        x = self.conv5(x)
+        x = self.conv6(x)
+        x = self.conv7(x)
+        x = self.pool3(x)
+        x = self.conv8(x)
+        x = self.conv9(x)
+        x = self.conv10(x)
+        x = self.ups1(x)
+        x = self.conv11(x)
+        x = self.conv12(x)
+        x = self.conv13(x)
+        x = self.ups2(x)
+        x = self.conv14(x)
+        x = self.conv15(x)
+        x = self.ups3(x)
+        x = self.conv16(x)
+        x = self.conv17(x)
+        x = self.conv18(x)
+        return x
+
+
+__all__ = ["ConvBlock", "BallTrackerNet"]

--- a/services/court_detector/utils_weights.py
+++ b/services/court_detector/utils_weights.py
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helpers for loading Tennis Court Detector checkpoints."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import torch
+
+
+def load_tcd_state_dict(path: str) -> Dict[str, Any]:
+    """Load a TCD checkpoint into a clean ``state_dict``.
+
+    The function normalizes common checkpoint layouts by unwrapping nested
+    dictionaries and stripping ``module.`` prefixes produced by ``DataParallel``.
+
+    Args:
+        path: Path to ``.pth`` file.
+
+    Returns:
+        Normalized state dictionary suitable for :func:`torch.nn.Module.load_state_dict`.
+    """
+
+    sd: Any = torch.load(path, map_location="cpu")
+    if isinstance(sd, dict) and "state_dict" in sd:
+        sd = sd["state_dict"]
+    if isinstance(sd, dict) and "model" in sd and isinstance(sd["model"], dict):
+        sd = sd["model"]
+    if isinstance(sd, dict):
+        sd = {k.replace("module.", ""): v for k, v in sd.items()}
+    return sd
+
+
+__all__ = ["load_tcd_state_dict"]

--- a/tests/test_postproc.py
+++ b/tests/test_postproc.py
@@ -1,0 +1,32 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`services.court_detector.postproc`."""
+
+import numpy as np
+
+from services.court_detector.postproc import heat_to_peak_xy, refine_kps_if_needed
+
+
+def test_heat_to_peak_xy() -> None:
+    """Peak finder should return coordinates of the maximum."""
+
+    heat = np.zeros((10, 10), dtype=np.uint8)
+    heat[2, 3] = 200
+    x, y = heat_to_peak_xy(heat)
+    assert (x, y) == (3, 2)
+
+
+def test_refine_kps_if_needed_noop() -> None:
+    """Refinement stub should leave coordinates unchanged."""
+
+    img = np.zeros((5, 5, 3), dtype=np.uint8)
+    assert refine_kps_if_needed(img, 1, 2, k_idx=0) == (1, 2)

--- a/tests/test_run_court.py
+++ b/tests/test_run_court.py
@@ -1,0 +1,156 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Integration tests for :mod:`services.court_detector.run_court`."""
+
+import json
+
+import numpy as np
+import pytest
+
+if not hasattr(np, "ndarray"):
+    pytest.skip("numpy not available", allow_module_level=True)
+
+import cv2
+import torch
+
+from services.court_detector.run_court import process_frames, build_argparser
+from services.court_detector.tcd_model import BallTrackerNet
+
+
+if not hasattr(torch, "zeros"):
+    pytest.skip("torch not available", allow_module_level=True)
+try:
+    torch.zeros(1)
+except Exception:  # pragma: no cover
+    pytest.skip("incomplete torch implementation", allow_module_level=True)
+
+
+def test_process_frames(tmp_path) -> None:
+    """Processing should create output JSON with placeholders."""
+
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    for i in range(3):
+        img = np.zeros((360, 640, 3), dtype=np.uint8)
+        cv2.imwrite(str(frames_dir / f"frame_{i:06d}.png"), img)
+
+    model = BallTrackerNet()
+    weights_path = tmp_path / "w.pth"
+    torch.save(model.state_dict(), weights_path)
+
+    out_json = tmp_path / "out.json"
+    process_frames(str(frames_dir), str(weights_path), str(out_json))
+
+    data = json.loads(out_json.read_text())
+    assert len(data) == 3
+    assert all(item["placeholder"] for item in data)
+
+
+def test_process_frames_accepts_various_formats(tmp_path) -> None:
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    # write jpg and png with generic names
+    img = np.zeros((360, 640, 3), dtype=np.uint8)
+    cv2.imwrite(str(frames_dir / "a.jpg"), img)
+    cv2.imwrite(str(frames_dir / "b.png"), img)
+
+    weights_path = tmp_path / "w.pth"
+    torch.save(BallTrackerNet().state_dict(), weights_path)
+
+    out_json = tmp_path / "out.json"
+    process_frames(str(frames_dir), str(weights_path), str(out_json))
+    data = json.loads(out_json.read_text())
+    assert len(data) == 2
+
+
+def test_natural_sorting(tmp_path) -> None:
+    """Frames should be processed in natural numeric order."""
+
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    order = ["frame_1.png", "frame_10.png", "frame_2.png"]
+    img = np.zeros((360, 640, 3), dtype=np.uint8)
+    for name in order:
+        cv2.imwrite(str(frames_dir / name), img)
+
+    weights_path = tmp_path / "w.pth"
+    torch.save(BallTrackerNet().state_dict(), weights_path)
+
+    out_json = tmp_path / "out.json"
+    process_frames(str(frames_dir), str(weights_path), str(out_json))
+    data = json.loads(out_json.read_text())
+    assert [d["frame"] for d in data] == ["frame_1.png", "frame_2.png", "frame_10.png"]
+
+
+def test_dump_kps_json(tmp_path) -> None:
+    """Keypoints JSON should be written when requested."""
+
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    img = np.zeros((360, 640, 3), dtype=np.uint8)
+    cv2.imwrite(str(frames_dir / "frame_000001.png"), img)
+
+    weights_path = tmp_path / "w.pth"
+    torch.save(BallTrackerNet().state_dict(), weights_path)
+
+    out_json = tmp_path / "out.json"
+    kp_json = tmp_path / "kps.json"
+    process_frames(
+        str(frames_dir),
+        str(weights_path),
+        str(out_json),
+        kp_json_path=str(kp_json),
+    )
+
+    data = json.loads(kp_json.read_text())
+    assert len(data) == 1
+    assert len(data[0]["kps"]) == 14
+
+
+def test_no_frames_exit_code(tmp_path) -> None:
+    """Missing frames should exit with code 2."""
+
+    frames_dir = tmp_path / "frames"
+    frames_dir.mkdir()
+    weights_path = tmp_path / "w.pth"
+    torch.save(BallTrackerNet().state_dict(), weights_path)
+    out_json = tmp_path / "out.json"
+
+    with pytest.raises(SystemExit) as exc:
+        process_frames(str(frames_dir), str(weights_path), str(out_json))
+    assert exc.value.code == 2
+
+
+def test_argparser_aliases() -> None:
+    parser = build_argparser()
+    ns = parser.parse_args(
+        [
+            "--frames-dir",
+            "in",
+            "--out-json",
+            "x.json",
+            "--stride",
+            "2",
+        ]
+    )
+    assert ns.output_json == "x.json"
+    assert ns.sample_rate == 2
+
+
+def test_argparser_kp_json() -> None:
+    """Parser should accept --dump-kps-json option."""
+
+    parser = build_argparser()
+    ns = parser.parse_args(
+        ["--frames-dir", "in", "--output-json", "out.json", "--dump-kps-json", "kps.json"]
+    )
+    assert ns.kp_json_path == "kps.json"

--- a/tests/test_tcd_model.py
+++ b/tests/test_tcd_model.py
@@ -1,0 +1,38 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`services.court_detector.tcd_model`."""
+
+import numpy as np
+import pytest
+
+if not hasattr(np, "ndarray"):
+    pytest.skip("numpy not available", allow_module_level=True)
+
+import torch
+from services.court_detector.tcd_model import BallTrackerNet
+
+
+if not hasattr(torch, "zeros"):
+    pytest.skip("torch not available", allow_module_level=True)
+try:  # ensure tensor creation works
+    torch.zeros(1)
+except Exception:  # pragma: no cover - environment limitation
+    pytest.skip("incomplete torch implementation", allow_module_level=True)
+
+
+def test_forward_shape() -> None:
+    """Model should return 15 heatmaps of size 360x640."""
+
+    model = BallTrackerNet()
+    x = torch.zeros(1, 3, 360, 640)
+    y = model(x)
+    assert y.shape == (1, 15, 360, 640)

--- a/tests/test_utils_weights.py
+++ b/tests/test_utils_weights.py
@@ -1,0 +1,35 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for :mod:`services.court_detector.utils_weights`."""
+
+import numpy as np
+import pytest
+
+if not hasattr(np, "ndarray"):
+    pytest.skip("numpy not available", allow_module_level=True)
+
+import torch
+from services.court_detector.utils_weights import load_tcd_state_dict
+
+
+if not hasattr(torch, "save"):
+    pytest.skip("torch not available", allow_module_level=True)
+
+
+def test_load_tcd_state_dict(tmp_path) -> None:
+    """Loader should unwrap nested keys and strip prefixes."""
+
+    ckpt = {"state_dict": {"module.conv.weight": 0}}
+    path = tmp_path / "ckpt.pth"
+    torch.save(ckpt, path)
+    sd = load_tcd_state_dict(str(path))
+    assert "conv.weight" in sd


### PR DESCRIPTION
## Summary
- enable optional CUDA execution and switch to `torch.inference_mode` in court detector runner
- guard heatmap overlays against empty logits and raise default mask threshold to 0.67
- allow conditional PyTorch wheel source in Dockerfile
- support JPEG/PNG frame globbing with CLI aliases and processing summary
- sort frames naturally and allow dumping raw keypoints per frame

## Testing
- `python -m pytest` *(fails: No module named pytest)*
- `pip install pytest` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68ad863e8d58832f84790bacd8612516