### PR TITLE
docs: document torch in base image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# Torch постачається базовим образом pytorch/pytorch:2.2.1-cuda12.1-cudnn8-runtime
+# Якщо колись знадобиться оновлення, робіть це в Dockerfile, а не тут.
 accelerate>=0.23.0
 click>=8.1
 cython_bbox>=0.1.3


### PR DESCRIPTION
## Summary
- clarify that PyTorch comes from the base `pytorch/pytorch:2.2.1-cuda12.1-cudnn8-runtime` image
- instruct contributors to update torch in Dockerfile rather than `requirements.txt`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedd736b48832f93a9cb5e174ad185