### PR TITLE
Add pipeline verification script and correct tracking entrypoint

### DIFF
--- a/Dockerfile.track
+++ b/Dockerfile.track
@@ -42,4 +42,6 @@ from bytetrack_vendor.tracker.byte_tracker import BYTETracker
 print('BYTETracker import OK', BYTETracker is not None)
 PY
 
-ENTRYPOINT ["python", "-m", "src.detect_objects"]
+# Коректний ENTRYPOINT для образу трекера.
+# Для одноразових команд можна перевизначити через --entrypoint.
+ENTRYPOINT ["python","-m","src.track"]

--- a/README.md
+++ b/README.md
@@ -312,12 +312,14 @@ docker run --gpus all --rm -v "$(pwd)":/app decoder-detect:latest \
 
 # 3) track – softer thresholds, wider buffers, stitching & smoothing
 # IMPORTANT: pass --frames-dir to auto-enable appearance refine
-docker run --gpus all --rm -v "$(pwd)":/app decoder-track:latest \
-  track --detections-json /app/detections.json \
-        --output-json /app/tracks.json \
-        --frames-dir /app/frames \
-        --fps 30 --min-score 0.28 \
-        --pre-nms-iou 0.6 --pre-min-area-q 0.15 --pre-topk 3 --pre-court-gate \
+docker run --gpus all --rm -v "$(pwd)":/app \
+  --entrypoint python decoder-track:latest \
+  -m src.track \
+  --detections-json /app/detections.json \
+  --output-json /app/tracks.json \
+  --frames-dir /app/frames \
+  --fps 30 --min-score 0.28 \
+  --pre-nms-iou 0.6 --pre-min-area-q 0.15 --pre-topk 3 --pre-court-gate \
         --p-match-thresh 0.55 --p-track-buffer 160 --reid-reuse-window 150 \
         --b-match-thresh 0.55 --b-track-buffer 150 --color-sim-w 0.10 \
         --stitch --stitch-iou 0.55 --stitch-gap 12 \
@@ -531,10 +533,12 @@ YOLOX modules need to be built.
 Only detections with score above ``--min-score`` are considered.
 
 ```bash
-docker run --gpus all --rm -v "$(pwd)":/app decoder-track:latest \
-    track --detections-json /app/detections.json \
-          --output-json /app/tracks.json \
-          --min-score 0.30
+docker run --gpus all --rm -v "$(pwd)":/app \
+  --entrypoint python decoder-track:latest \
+  -m src.track \
+  --detections-json /app/detections.json \
+  --output-json /app/tracks.json \
+  --min-score 0.30
 ```
 
 * ``--detections-json`` – input file produced by the detection step.
@@ -747,28 +751,32 @@ This prints the number of invalid bounding boxes and low-confidence detections.
   The image sets ``PYTHONPATH`` before verifying the ByteTrack vendor to avoid
   ``ModuleNotFoundError`` during the build-time sanity check.
 
-- **Run:**
+  - **Run:**
 
-  ```bash
-  docker run --gpus all --rm -v "$(pwd)":/app decoder-track:latest \
-      track --detections-json /app/detections.json \
-            --output-json /app/tracks.json \
-            --fps 30 --min-score 0.10
-  ```
+    ```bash
+    docker run --gpus all --rm -v "$(pwd)":/app \
+      --entrypoint python decoder-track:latest \
+      -m src.track \
+      --detections-json /app/detections.json \
+      --output-json /app/tracks.json \
+      --fps 30 --min-score 0.10
+    ```
 
   **Enhanced example with pre/post processing:**
 
-  ```bash
-  docker run --gpus all --rm -v "$(pwd)":/app decoder-track:latest \
-      track --detections-json /app/detections.json \
-            --output-json /app/tracks.json \
-            --fps 30 --min-score 0.28 \
-            --pre-nms-iou 0.6 --pre-min-area-q 0.5 --pre-topk 3 --pre-court-gate \
-            --p-match-thresh 0.60 --p-track-buffer 125 --reid-reuse-window 125 \
-            --stitch --stitch-iou 0.55 --stitch-gap 5 \
-            --ball-max-area-q 0.01 --ball-max-accel 20000 --ball-max-speed 3000 \
-            --smooth ema --smooth-alpha 0.3
-  ```
+    ```bash
+    docker run --gpus all --rm -v "$(pwd)":/app \
+      --entrypoint python decoder-track:latest \
+      -m src.track \
+      --detections-json /app/detections.json \
+      --output-json /app/tracks.json \
+      --fps 30 --min-score 0.28 \
+      --pre-nms-iou 0.6 --pre-min-area-q 0.5 --pre-topk 3 --pre-court-gate \
+      --p-match-thresh 0.60 --p-track-buffer 125 --reid-reuse-window 125 \
+      --stitch --stitch-iou 0.55 --stitch-gap 5 \
+      --ball-max-area-q 0.01 --ball-max-accel 20000 --ball-max-speed 3000 \
+      --smooth ema --smooth-alpha 0.3
+    ```
 
   *Optional colour check:* add `--appearance-refine --appearance-lambda 0.3 --frames-dir /app/frames`.
 

--- a/scripts/verify_all.sh
+++ b/scripts/verify_all.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# End-to-end перевірка пайплайна: court -> map -> detect -> track -> overlay -> mp4
+# Образи: decoder-court:cuda, decoder-detect:latest, decoder-track:latest
+
+set -euo pipefail
+
+# ---------------------------- НАЛАШТУВАННЯ -------------------------------------
+UIDGID="$(id -u):$(id -g)"
+DOCKER_USER=${DOCKER_USER:---user "$(id -u):$(id -g)"}
+
+FRAMES_DIR="${FRAMES_DIR:-$(pwd)/frames}"
+WEIGHTS_TCD="${WEIGHTS_TCD:-$(pwd)/weights/tcd.pth}"
+FPS="${FPS:-30}"
+
+OUT_DIR="$(pwd)"
+COURT_JSON="${OUT_DIR}/court.json"
+COURT_BY_NAME="${OUT_DIR}/court_by_name.json"
+DETECTIONS_JSON="${OUT_DIR}/detections.json"
+TRACKS_JSON="${OUT_DIR}/tracks.json"
+PREVIEW_DIR="${OUT_DIR}/preview_tracks"
+PREVIEW_MP4="${OUT_DIR}/preview_tracks.mp4"
+
+# Параметри моделей (узгоджено з останніми комітами/логами)
+DETECT_FLAGS=${DETECT_FLAGS:-"--two-pass --nms-class-aware --multi-scale on --img-size 1536 --p-conf 0.30 --b-conf 0.05 --p-nms 0.60 --b-nms 0.70 --roi-json /app/court.json --roi-margin 8"}
+TRACK_FLAGS=${TRACK_FLAGS:-"--fps ${FPS} --min-score 0.10"}
+DRAW_FLAGS=${DRAW_FLAGS:-"--mode track --id --label --draw-court --draw-court-lines --roi-json /app/court.json"}
+
+die() { echo "[ERROR] $*" >&2; exit 2; }
+
+check_prereqs() {
+  command -v docker >/dev/null 2>&1 || die "Потрібен Docker"
+  [ -d "$FRAMES_DIR" ] || die "Не знайдено frames dir: $FRAMES_DIR"
+  [ -f "$WEIGHTS_TCD" ] || die "Не знайдено ваги корту: $WEIGHTS_TCD"
+}
+
+check_space() {
+  local avail_kb
+  avail_kb=$(df -Pk "$OUT_DIR" | awk 'NR==2{print $4}')
+  if [ "$avail_kb" -lt $((2*1024*1024)) ]; then
+    echo "[WARN] Мало місця на диску: ~$((avail_kb/1024)) MB"
+  fi
+}
+
+fix_permissions() {
+  chown "$(id -u)":"$(id -g)" "$@" 2>/dev/null || true
+  chmod 644 "$@" 2>/dev/null || true
+}
+
+py_host() { python - "$@"; }
+
+summary_json() {
+  local path="$1"
+  py_host "$path" <<'PY'
+import json,sys,os
+p=sys.argv[1]
+if not os.path.exists(p):
+    print(f"[summary] {p}: not found"); sys.exit(0)
+with open(p,"r",encoding="utf-8") as f:
+    d=json.load(f)
+n = len(d) if hasattr(d,'__len__') else 'n/a'
+print(f"[summary] {os.path.basename(p)} type={type(d).__name__} len={n}")
+if isinstance(d, list) and d:
+    print("[summary] first keys:", list(d[0])[:8])
+elif isinstance(d, dict) and d:
+    print("[summary] first 5 keys:", list(d.keys())[:5])
+PY
+}
+
+maybe_extract_frames() {
+  if [ -z "$(find "$FRAMES_DIR" -maxdepth 1 -type f -name '*.*' | head -n1)" ]; then
+    echo "[INFO] frames/ пустий — екстрагуємо з input.mp4 (опційно)"
+    [ -f "$(pwd)/input.mp4" ] || die "Немає frames/ і немає input.mp4"
+    docker run --rm $DOCKER_USER -v "$(pwd)":/app --entrypoint ffmpeg decoder-track:latest \
+      -i /app/input.mp4 -vf "fps=${FPS}" /app/frames/frame_%06d.png
+  fi
+}
+
+run_court() {
+  echo "[STEP] Court detection -> ${COURT_JSON}"
+  rm -f "$COURT_JSON"
+  docker run --rm --gpus all $DOCKER_USER -v "$(pwd)":/app decoder-court:cuda \
+    --frames-dir /app/frames \
+    --output-json /app/court.json \
+    --device cuda \
+    --weights /app/weights/tcd.pth \
+    --sample-rate 4 \
+    --min-score 0.55 --score-metric max --mask-thr 0.30
+  fix_permissions "$COURT_JSON"
+  summary_json "$COURT_JSON"
+
+  echo "[STEP] Court diagnostics (diag_court.py)"
+  rm -f H_CHECK_TOP.txt 2>/dev/null || true
+  docker run --rm $DOCKER_USER -v "$(pwd)":/app --entrypoint python \
+    decoder-track:latest /app/tools/diag_court.py --court /app/court.json || true
+  [ -f H_CHECK_TOP.txt ] && { chown "$(id -u)":"$(id -g)" H_CHECK_TOP.txt 2>/dev/null || true; chmod 644 H_CHECK_TOP.txt 2>/dev/null || true; }
+}
+
+run_court_map() {
+  echo "[STEP] Court→Frame mapping -> ${COURT_BY_NAME}"
+  ./scripts/run_court_map.sh
+  fix_permissions "$COURT_BY_NAME"
+  summary_json "$COURT_BY_NAME"
+}
+
+run_detect() {
+  echo "[STEP] Detection -> ${DETECTIONS_JSON}"
+  rm -f "$DETECTIONS_JSON"
+  docker run --gpus all --rm $DOCKER_USER -v "$(pwd)":/app \
+    decoder-detect:latest detect \
+      --frames-dir /app/frames \
+      --output-json /app/detections.json \
+      ${DETECT_FLAGS}
+  fix_permissions "$DETECTIONS_JSON"
+  summary_json "$DETECTIONS_JSON"
+
+  # Підсумок по класах (підтримує list/dict та 'detections'/'objects', 'class'/'cls')
+  py_host "$DETECTIONS_JSON" <<'PY'
+import json,sys,collections
+p=sys.argv[1]; d=json.load(open(p,'r',encoding='utf-8'))
+ctr=collections.Counter()
+def bump(rec):
+    if not isinstance(rec,dict): return
+    arr = rec.get('detections') or rec.get('objects') or []
+    for o in arr:
+        k = o.get('class', o.get('cls'))
+        if k is not None:
+            ctr[str(k)] += 1
+if isinstance(d,list):
+    for rec in d: bump(rec)
+elif isinstance(d,dict):
+    for _,rec in d.items(): bump(rec)
+print("[summary] classes:", dict(ctr))
+PY
+}
+
+run_track() {
+  echo "[STEP] Tracking -> ${TRACKS_JSON}"
+  rm -f "$TRACKS_JSON"
+  # Явно запускаємо модуль трекера, щоб не зловити ENTRYPOINT детектора
+  docker run --gpus all --rm $DOCKER_USER -v "$(pwd)":/app \
+    --entrypoint python decoder-track:latest \
+      -m src.track \
+      --detections-json /app/detections.json \
+      --output-json /app/tracks.json \
+      ${TRACK_FLAGS}
+  fix_permissions "$TRACKS_JSON"
+  summary_json "$TRACKS_JSON"
+}
+
+run_overlay() {
+  echo "[STEP] Overlay rendering -> ${PREVIEW_DIR} + ${PREVIEW_MP4}"
+  rm -rf "$PREVIEW_DIR" "$PREVIEW_MP4"
+  docker run --rm $DOCKER_USER -v "$(pwd)":/app --entrypoint python \
+    decoder-track:latest \
+      -m src.draw_overlay \
+      --frames-dir /app/frames \
+      --tracks-json /app/tracks.json \
+      --output-dir /app/preview_tracks \
+      --export-mp4 /app/preview_tracks.mp4 \
+      --fps ${FPS} --crf 18 \
+      ${DRAW_FLAGS}
+  [ -f "$PREVIEW_MP4" ] && fix_permissions "$PREVIEW_MP4"
+  [ -d "$PREVIEW_DIR" ] && chmod -R a+r "$PREVIEW_DIR" 2>/dev/null || true
+  ls -lh "$PREVIEW_MP4" 2>/dev/null || echo "[INFO] MP4 не створено (перевірте логи)"
+}
+
+# --------------------------------- MAIN ---------------------------------------
+check_prereqs
+check_space
+maybe_extract_frames
+run_court
+run_court_map
+run_detect
+run_track
+run_overlay
+echo "[OK] Пайплайн завершено"

--- a/tools/diag_court.py
+++ b/tools/diag_court.py
@@ -81,7 +81,17 @@ def main(argv: Iterable[str] | None = None) -> int:
 
     top = sorted(entries, key=lambda x: x[1], reverse=True)[:25]
     lines = [f"{f}\t{e:.2f}\t{d:.3f}\n" for f, e, d in top]
-    Path("H_CHECK_TOP.txt").write_text("".join(lines))
+    # Пишемо файл поруч із court.json, атомарно та без проблем з правами
+    out_dir = Path(args.court).resolve().parent
+    out_path = out_dir / "H_CHECK_TOP.txt"
+    try:
+        if out_path.exists():
+            out_path.unlink()
+    except Exception:
+        pass
+    tmp = out_dir / ".tmp_H_CHECK_TOP.txt"
+    tmp.write_text("".join(lines), encoding="utf-8")
+    tmp.replace(out_path)
     return 0
 
 


### PR DESCRIPTION
## Summary
- add `scripts/verify_all.sh` for court→detect→track→overlay verification
- write `H_CHECK_TOP.txt` atomically in `diag_court.py`
- set tracker image ENTRYPOINT to `src.track` and document explicit usage

## Testing
- `pytest` *(fails: AttributeError: partially initialized module 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68b5cd2d3acc832f9c2e099c661372dc