### PR TITLE
Ensure homography uses canonical polygon order

### DIFF
--- a/src/draw_overlay.py
+++ b/src/draw_overlay.py
@@ -317,10 +317,13 @@ def _ensure_H(rec: Dict[str, Any]) -> Optional[np.ndarray]:
         return np.asarray(H, dtype=float)
     quad = normalize_quad(rec.get("polygon"))
     if quad is not None:
+        # IMPORTANT: bring polygon to canonical TL, TR, BR, BL order
+        dst = _order_poly(quad)
         src = np.float32([[0, 0], [1, 0], [1, 1], [0, 1]])
-        dst = np.float32(quad)
         Hm = cv2.getPerspectiveTransform(src, dst)
-        LOGGER.debug("[ROI] homography: computed from quad")
+        LOGGER.debug(
+            "[ROI] homography: computed from quad (ordered TL,TR,BR,BL)"
+        )
         return Hm
     return None
 


### PR DESCRIPTION
## Summary
- order ROI polygons before computing homography to maintain TL,TR,BR,BL convention
- log that homography derives from ordered quad
- add regression test ensuring vertex order does not affect computed transform

## Testing
- `pytest tests/test_draw_overlay.py::test_ensure_H_orders_quad -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6d0e78bd4832f8fe6935509215889